### PR TITLE
Complete failing test for amaembo/streamex#29

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,12 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>commons-net</groupId>
+      <artifactId>commons-net</artifactId>
+      <version>3.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <developers>


### PR DESCRIPTION
This is a simplified (and ugly+hardcoded) version of my work.
Basically I'm manipulating networks in CIDR notation and I want to collapse networks that are already defined.
In this modified version of your test I stream the parent net followed by 50 of it's child.
I expect the child to be collapsed / ignored due to the parent net presence.