### PR TITLE
Corrected JavaDocs for the methods EntryStream#toMap(BinaryOperator) and EntryStream#toSortedMap(BinaryOperator)

### DIFF
--- a/src/main/java/one/util/streamex/EntryStream.java
+++ b/src/main/java/one/util/streamex/EntryStream.java
@@ -1024,8 +1024,6 @@ public class EntryStream<K, V> extends AbstractStreamEx<Entry<K, V>, EntryStream
      *        values associated with the same key, as supplied to
      *        {@link Map#merge(Object, Object, BiFunction)}
      * @return a {@code Map} containing the elements of this stream
-     * @throws IllegalStateException if duplicate key was encountered in the
-     *         stream
      * @see Collectors#toMap(Function, Function)
      * @see Collectors#toConcurrentMap(Function, Function)
      * @since 0.1.0
@@ -1144,8 +1142,6 @@ public class EntryStream<K, V> extends AbstractStreamEx<Entry<K, V>, EntryStream
      *        values associated with the same key, as supplied to
      *        {@link Map#merge(Object, Object, BiFunction)}
      * @return a {@code SortedMap} containing the elements of this stream
-     * @throws IllegalStateException if duplicate key was encountered in the
-     *         stream
      * @see Collectors#toMap(Function, Function)
      * @see Collectors#toConcurrentMap(Function, Function)
      * @since 0.1.0


### PR DESCRIPTION
Corrected JavaDocs for the methods EntryStream#toMap(BinaryOperator<V> mergeFunction) and
EntryStream#toSortedMap(BinaryOperator<V> mergeFunction) as they do not throw IllegalStateException if duplicate key was encountered in the stream.