### PR TITLE
Avoids creation of an array when appending a single key-value pair to EntryStream.

### DIFF
--- a/src/main/java/one/util/streamex/EntryStream.java
+++ b/src/main/java/one/util/streamex/EntryStream.java
@@ -301,8 +301,8 @@ public class EntryStream<K, V> extends AbstractStreamEx<Entry<K, V>, EntryStream
      * @return the new stream
      */
     public EntryStream<K, V> append(K key, V value) {
-        return appendSpliterator(null, Arrays.<Entry<K, V>> asList(new SimpleImmutableEntry<>(key, value))
-                .spliterator());
+        return appendSpliterator(null, Collections.<Entry<K, V>> singleton(
+            new SimpleImmutableEntry<>(key, value)).spliterator());
     }
 
     /**


### PR DESCRIPTION
Uses Collections.singleton() instead of Arrays.asList() to get the Splitterator for a single element.