### PR TITLE
167 to map by key

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,14 @@ Check also [MIGRATION.md](MIGRATION.md) for possible compatibility problems.
 * [#76] Added: `StreamEx.zipWith` accepting `BaseStream` (so zipWith(IntStreamEx.ints()) works)
 * [#131] Added: `StreamEx.ofCombinations`
 * [#164] Added: `Joining.maxElements`
+<!---
+TODO: finalize when adjusted with repository owner
+* [#167]:
+    - Added: [`StreamEx.toMapByKey(Function)`](reference to diff or PR)
+and [`StreamEx.toMapByValue(Function)`](reference to diff or PR)
+    - deprecated `StreamEx.toMap(Function)` in a favour of
+    `StreamEx.toMapByValue(Function)`
+--->
 
 ### 0.6.6
 * [#145] Added: `intersperse` method for all stream types.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,15 @@
 
 This document describes StreamEx changes which may break the backwards compatibility. For full list of changes see [CHANGES.md](CHANGES.md).
 
+<!---
+ TODO: finalize when adjusted with repository owner
+### 0.6.7
+
+Issue#167: Now `StreamEx.toMap(Function) is deprecated
+in a favour of `StreamEx.toMapByValue(Function).
+The implementation is not changed though.
+-->
+
 ### 0.6.0
 
 Issue#67: Now `StreamEx.withFirst()` as well as `StreamEx.withFirst(BinaryOperator)` include `(first, first)` pair. If you used these operations in StreamEx 0.5.3-0.5.5, you should update the existing code: replace `.withFirst()` with `.withFirst().skip(1)`.

--- a/src/main/java/one/util/streamex/StreamEx.java
+++ b/src/main/java/one/util/streamex/StreamEx.java
@@ -903,6 +903,15 @@ public class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
     }
 
     /**
+     * @see #toMapByValue(Function)
+     * @deprecated As of version 0.6.7, replaced by {@link #toMapByValue(Function)}
+     */
+    @Deprecated
+    public <V> Map<T, V> toMap(Function<? super T, ? extends V> valMapper) {
+        return toMap(Function.identity(), valMapper);
+    }
+
+    /**
      * Returns a {@link Map} whose keys are elements from this stream and values
      * are the result of applying the provided mapping functions to the input
      * elements.
@@ -925,10 +934,40 @@ public class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
      *         (according to {@link Object#equals(Object)})
      * @see Collectors#toMap(Function, Function)
      * @see Collectors#toConcurrentMap(Function, Function)
+     * @see #toMapByKey(Function)
      * @see #toMap(Function, Function)
      */
-    public <V> Map<T, V> toMap(Function<? super T, ? extends V> valMapper) {
+    public <V> Map<T, V> toMapByValue(Function<? super T, ? extends V> valMapper) {
         return toMap(Function.identity(), valMapper);
+    }
+
+    /**
+     * Returns a {@link Map} whose keys are the result of provided {@code keyMapper}
+     * mapping function and the values are the elements from this stream.
+     *
+     * <p>
+     * This is a <a href="package-summary.html#StreamOps">terminal</a>
+     * operation.
+     *
+     * <p>
+     * Returned {@code Map} is guaranteed to be modifiable.
+     *
+     * <p>
+     * For parallel stream the concurrent {@code Map} is created.
+     *
+     * @param <K> the output type of the key mapping function
+     * @param keyMapper a mapping function to produce keys
+     * @return a {@code Map} whose keys are whose keys are the result of provided
+     *         key mapping function and the values are the elements from this stream.
+     * @throws IllegalStateException if this stream contains elements which are mapped
+     *         to duplicate keys (according to {@link Object#equals(Object)})
+     * @see Collectors#toMap(Function, Function)
+     * @see Collectors#toConcurrentMap(Function, Function)
+     * @see #toMapByValue(Function)
+     * @see #toMap(Function, Function)
+     */
+    public <K> Map<K, T> toMapByKey(Function<? super T, ? extends K> keyMapper) {
+        return toMap(keyMapper, Function.identity());
     }
 
     /**

--- a/src/test/java/one/util/streamex/TestHelpers.java
+++ b/src/test/java/one/util/streamex/TestHelpers.java
@@ -415,4 +415,23 @@ public class TestHelpers {
                 fail("wrong exception message: " + exmsg);
         }
     }
+
+    /**
+     * Verify the map is modifiable, as described in the doc.
+     * <p>
+     * The assertion puts the key-value entry to the map, verifies the size is incremented
+     * and value is successfully fetched from the map.
+     *
+     * @param map        {@link Map} instance to verify (put a value)
+     * @param keyToPut   key to assign in the map. The key must be unique for this map
+     * @param valueToPut value to associate with the {@code keyToPut}
+     * @param <K>        type of map key
+     * @param <V>        type of map value
+     */
+    static <K, V> void assertMapIsModifiable(Map<K, V> map, K keyToPut, V valueToPut) {
+        final int initialSize = map.size();
+        map.put(keyToPut, valueToPut);
+        assertEquals(map.size(), initialSize + 1);
+        assertEquals(map.get(keyToPut), valueToPut);
+    }
 }


### PR DESCRIPTION
As a proof-of-concept for the issue #167 :
  - added [`toMapByKey(Function)`](https://github.com/amaembo/streamex/pull/168/files#diff-7b5acdd4c986f31903426a534ba731f3R969) method
  - `toMap(Function)` is copied to [`toMapByValue(Function)`](https://github.com/amaembo/streamex/pull/168/files#diff-7b5acdd4c986f31903426a534ba731f3R940)
  - `toMap(Function)` is [marked as deprecated](https://github.com/amaembo/streamex/pull/168/files#diff-7b5acdd4c986f31903426a534ba731f3R907)

As minor boy-scout tests extension:
  - added tests verifying the returned maps of `toMap(Function)`, `toMapByKey(Function)` and `toMapByValue(Function)` are mutable, as explicitly specified by documentation. See [`assertMapIsModifiable()`](https://github.com/amaembo/streamex/pull/168/files#diff-b7785b58053970901c997b14fa92d22cR431)