### PR TITLE
Fix type inference issue when upgrading from javac 8 to 9.

### DIFF
--- a/src/main/java/one/util/streamex/EntryStream.java
+++ b/src/main/java/one/util/streamex/EntryStream.java
@@ -549,7 +549,7 @@ public class EntryStream<K, V> extends AbstractStreamEx<Entry<K, V>, EntryStream
     public <R> StreamEx<R> mapKeyValuePartial(
             BiFunction<? super K, ? super V, ? extends Optional<? extends R>> mapper
     ) {
-        return mapPartial(toFunction(mapper));
+        return this.<R>mapPartial(toFunction(mapper));
     }
 
     /**


### PR DESCRIPTION
In https://bugs.openjdk.java.net/browse/JDK-8033718 upstream fixed a bug where type inference wasn't properly handling capture variables as upper bounds.  This causes a backwards incompatibility in versions of javac that include this fix, starting with 9.  This change adds an explicit type argument to work around the incompatiblity.