### PR TITLE
Update maven-javadoc-plugin to 3.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
         <executions>
           <execution>
             <!-- This execution used just to run javadoc with doclint and 


### PR DESCRIPTION
I encountered following difficulty while preparing #203:

using

```
Apache Maven 3.6.2 (40f52333136460af0dc0d7232c0dc0bcf0d9e117; 2019-08-27T17:06:16+02:00)
Maven home: /usr/local/Cellar/maven/3.6.2/libexec
Java version: 11.0.3, vendor: Oracle Corporation, runtime: /Users/evgeny.mandrikov/.java-select/versions/jdk-11.0.3_osx-x64_bin
Default locale: en_FR, platform encoding: UTF-8
OS name: "mac os x", version: "10.14.5", arch: "x86_64", family: "mac"
```

`mvn package` fails as following

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.0.0:javadoc (verify-javadocs) on project streamex: Execution verify-javadocs of goal org.apache.maven.plugins:maven-javadoc-plugin:3.0.0:javadoc failed.: NullPointerException -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.0.0:javadoc (verify-javadocs) on project streamex: Execution verify-javadocs of goal org.apache.maven.plugins:maven-javadoc-plugin:3.0.0:javadoc failed.
Caused by: org.apache.maven.plugin.PluginExecutionException: Execution verify-javadocs of goal org.apache.maven.plugins:maven-javadoc-plugin:3.0.0:javadoc failed.
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:148)
Caused by: java.lang.NullPointerException
    at org.apache.commons.lang3.SystemUtils.isJavaVersionAtLeast (SystemUtils.java:1626)
```

update of `maven-javadoc-plugin` to `3.1.0` and latest `3.1.1` do not help - they both fail as following

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.1.1:javadoc (verify-javadocs) on project streamex: An error has occurred in Javadoc report generation:
[ERROR] Exit code: 2 - error: option --module-path not allowed with target 1.8
[ERROR] error: option --add-modules not allowed with target 1.8
[ERROR] error: option --patch-module not allowed with target 1.8
```

however update to `3.0.1` helps.

@amaembo I'm wondering how you overcome these and why build works in Travis?