### PR TITLE
Issue/#43 add morecollectors tomap methods

### DIFF
--- a/src/main/java/one/util/streamex/MoreCollectors.java
+++ b/src/main/java/one/util/streamex/MoreCollectors.java
@@ -181,7 +181,6 @@ public final class MoreCollectors {
      *         (according to {@link Object#equals(Object)}).
      *
      * @see #entriesToMap(BinaryOperator)
-     * @see #entriesToMap(Function)
      * @see #entriesToMap(Function, BinaryOperator)
      * @see Collectors#toMap(Function, Function)
      * @since 0.7.3
@@ -209,7 +208,6 @@ public final class MoreCollectors {
      * using the {@code combiner} function
      *
      * @see #entriesToMap()
-     * @see #entriesToMap(Function)
      * @see #entriesToMap(Function, BinaryOperator)
      * @see Collectors#toMap(Function, Function, BinaryOperator)
      * @since 0.7.3
@@ -217,34 +215,6 @@ public final class MoreCollectors {
     public static <K, V> Collector<Entry<? extends K, ? extends V>, ?, Map<K, V>> entriesToMap(
             BinaryOperator<V> combiner) {
         return Collectors.toMap(Entry::getKey, Entry::getValue, combiner);
-    }
-
-    /**
-     * Returns a {@code Collector} that accumulates elements into a {@code Map}
-     * whose keys are taken from {@code Map.Entry} and values are the result
-     * of applying the provided {@code valueMapper} function.
-     *
-     * @param <K>         the {@link Comparable} type of then map keys
-     * @param <V>         the type of the map values
-     * @param <VV>        the output type of the value mapping function
-     * @param valueMapper a mapping function to produce values from {@code Map.Entry} values
-     * @return {@code Collector} which collects elements into a {@code Map}
-     * whose keys are taken from {@code Map.Entry} and values are the result of applying
-     * the provided {@code valueMapper} function to {@code Map.Entry} values.
-     * @throws IllegalStateException if this stream contains duplicate keys
-     *                               (according to {@link Object#equals(Object)}).
-     * @throws NullPointerException if mapper is null.
-     *
-     * @see #entriesToMap()
-     * @see #entriesToMap(BinaryOperator)
-     * @see #entriesToMap(Function, BinaryOperator)
-     * @see Collectors#toMap(Function, Function)
-     * @since 0.7.3
-     */
-    public static <K, V, VV> Collector<Entry<? extends K, ? extends V>, ?, Map<K, VV>> entriesToMap(
-            Function<V, VV> valueMapper) {
-        Objects.requireNonNull(valueMapper);
-        return Collectors.toMap(Entry::getKey, entry -> valueMapper.apply(entry.getValue()));
     }
 
     /**
@@ -268,7 +238,6 @@ public final class MoreCollectors {
      *
      * @see #entriesToMap()
      * @see #entriesToMap(BinaryOperator)
-     * @see #entriesToMap(Function)
      * @see Collectors#toMap(Function, Function, BinaryOperator)
      * @since 0.7.3
      */
@@ -292,7 +261,6 @@ public final class MoreCollectors {
      * @throws IllegalStateException if this stream contains duplicate keys
      *                               (according to {@link Object#equals(Object)}).
      *
-     * @see #entriesToCustomMap(Function, Supplier)
      * @see #entriesToCustomMap(BinaryOperator, Supplier)
      * @see #entriesToCustomMap(Function, BinaryOperator, Supplier)
      * @see Collectors#toMap(Function, Function, BinaryOperator, Supplier)
@@ -301,37 +269,6 @@ public final class MoreCollectors {
     public static <K, V, M extends Map<K, V>> Collector<Entry<? extends K, ? extends V>, ?, M> entriesToCustomMap(
             Supplier<M> mapSupplier) {
         return Collectors.toMap(Entry::getKey, Entry::getValue, throwingMerger(), mapSupplier);
-    }
-
-    /**
-     * Returns a {@code Collector} that accumulates elements into
-     * a result {@code Map} defined by {@code mapSupplier} function
-     * whose keys are taken from {@code Map.Entry} and values are the result
-     * of applying the provided {@code valueMapper} function.
-     *
-     * @param <K>         the {@link Comparable} type of then map keys
-     * @param <V>         the type of the map values
-     * @param <VV>        the output type of the value mapping function
-     * @param <M>         the type of the resulting {@code Map}
-     * @param valueMapper a mapping function to produce values from {@code Map.Entry} values
-     * @return {@code Collector} which collects elements into a {@code Map}
-     * defined by {@code mapSupplier} function whose keys are taken
-     * from {@code Map.Entry} and values are the result of applying
-     * the provided {@code valueMapper} function to {@code Map.Entry} values.
-     * @throws IllegalStateException if this stream contains duplicate keys
-     *                               (according to {@link Object#equals(Object)}).
-     * @throws NullPointerException if mapper is null.
-     *
-     * @see #entriesToCustomMap(Supplier)
-     * @see #entriesToCustomMap(BinaryOperator, Supplier)
-     * @see #entriesToCustomMap(Function, BinaryOperator, Supplier)
-     * @see Collectors#toMap(Function, Function, BinaryOperator, Supplier)
-     * @since 0.7.3
-     */
-    public static <K, V, VV, M extends Map<K, VV>> Collector<Entry<? extends K, ? extends V>, ?, M> entriesToCustomMap(
-            Function<V, VV> valueMapper, Supplier<M> mapSupplier) {
-        Objects.requireNonNull(valueMapper);
-        return Collectors.toMap(Entry::getKey, entry -> valueMapper.apply(entry.getValue()), throwingMerger(), mapSupplier);
     }
 
     /**
@@ -357,7 +294,6 @@ public final class MoreCollectors {
      * using the {@code combiner} function
      *
      * @see #entriesToCustomMap(Supplier)
-     * @see #entriesToCustomMap(Function, Supplier)
      * @see #entriesToCustomMap(Function, BinaryOperator, Supplier)
      * @see Collectors#toMap(Function, Function, BinaryOperator, Supplier)
      * @since 0.7.3
@@ -394,7 +330,6 @@ public final class MoreCollectors {
      * @throws NullPointerException if mapper is null.
      *
      * @see #entriesToCustomMap(Supplier)
-     * @see #entriesToCustomMap(Function, Supplier)
      * @see #entriesToCustomMap(BinaryOperator, Supplier)
      * @see Collectors#toMap(Function, Function, BinaryOperator, Supplier)
      * @since 0.7.3

--- a/src/main/java/one/util/streamex/MoreCollectors.java
+++ b/src/main/java/one/util/streamex/MoreCollectors.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
@@ -167,6 +168,61 @@ public final class MoreCollectors {
             return s1;
         }, Function.identity(), set -> set.size() == size, UNORDERED_ID_CHARACTERISTICS);
     }
+
+
+    public static <K, V> Collector<Entry<K, V>, ?, Map<K, V>> toMap() {
+        return Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue);
+    }
+
+    public static <K, V> Collector<Entry<K, V>, ?, ConcurrentMap<K, V>> toConcurrentMap() {
+        return Collectors.toConcurrentMap(Map.Entry::getKey, Map.Entry::getValue);
+    }
+
+    public static <K, V> Collector<Entry<K, V>, ?, Map<K, V>> toMap(
+            BinaryOperator<V> combiner) {
+
+        return Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, combiner);
+    }
+
+    public static <K, V, VV> Collector<Entry<K, V>, ?, Map<K, VV>> toMap(
+            Function<V, VV> valueMapper) {
+
+        return null;
+    }
+
+    public static <K, V, VV> Collector<Entry<K, V>, ?, Map<K, VV>> toMap(
+            Function<V, VV> valueMapper, BinaryOperator<VV> combiner) {
+
+        Objects.requireNonNull(valueMapper);
+        return null;
+    }
+
+    public static <K, V, M extends Map<K, V>> Collector<Entry<K, V>, ?, M> toCustomMap(
+            Supplier<M> mapSupplier) {
+
+        return null;
+    }
+
+    public static <K, V, VV, M extends Map<K, VV>> Collector<Entry<K, V>, ?, M> toCustomMap(
+            Function<V, VV> valueMapper, Supplier<M> mapSupplier) {
+
+        Objects.requireNonNull(valueMapper);
+        return null;
+    }
+
+    public static <K, V, M extends Map<K, V>> Collector<Entry<K, V>, ?, M> toCustomMap(
+            BinaryOperator<V> combiner, Supplier<M> mapSupplier) {
+
+        return null;
+    }
+
+    public static <K, V, VV, M extends Map<K, VV>> Collector<Entry<K, V>, ?, M> toCustomMap(
+            Function<V, VV> valueMapper, BinaryOperator<VV> combiner, Supplier<M> mapSupplier) {
+
+        Objects.requireNonNull(valueMapper);
+        return null;
+    }
+
 
     /**
      * Returns a {@code Collector} which counts a number of distinct values the

--- a/src/main/java/one/util/streamex/MoreCollectors.java
+++ b/src/main/java/one/util/streamex/MoreCollectors.java
@@ -180,7 +180,11 @@ public final class MoreCollectors {
      * @throws IllegalStateException if this stream contains duplicate keys
      *         (according to {@link Object#equals(Object)})
      *
+     * @see #entriesToMap(BinaryOperator)
+     * @see #entriesToMap(Function)
+     * @see #entriesToMap(Function, BinaryOperator)
      * @see Collectors#toMap(Function, Function)
+     * @since 0.7.3
      */
     public static <K, V> Collector<Entry<K, V>, ?, Map<K, V>> entriesToMap() {
         return Collectors.toMap(Entry::getKey, Entry::getValue);
@@ -204,7 +208,11 @@ public final class MoreCollectors {
      * whose keys and values are taken from {@code Map.Entry} and combining them
      * using the {@code combiner} function
      *
+     * @see #entriesToMap()
+     * @see #entriesToMap(Function)
+     * @see #entriesToMap(Function, BinaryOperator)
      * @see Collectors#toMap(Function, Function, BinaryOperator)
+     * @since 0.7.3
      */
     public static <K, V> Collector<Entry<K, V>, ?, Map<K, V>> entriesToMap(BinaryOperator<V> combiner) {
         return Collectors.toMap(Entry::getKey, Entry::getValue, combiner);
@@ -225,7 +233,11 @@ public final class MoreCollectors {
      * @throws IllegalStateException if this stream contains duplicate keys
      *                               (according to {@link Object#equals(Object)})
      *
+     * @see #entriesToMap()
+     * @see #entriesToMap(BinaryOperator)
+     * @see #entriesToMap(Function, BinaryOperator)
      * @see Collectors#toMap(Function, Function)
+     * @since 0.7.3
      */
     public static <K, V, VV> Collector<Entry<K, V>, ?, Map<K, VV>> entriesToMap(Function<V, VV> valueMapper) {
         return Collectors.toMap(Entry::getKey, entry -> valueMapper.apply(entry.getValue()));
@@ -249,7 +261,11 @@ public final class MoreCollectors {
      * of applying the provided {@code valueMapper} function and combining
      * them using the provided {@code combiner} function.
      *
+     * @see #entriesToMap()
+     * @see #entriesToMap(BinaryOperator)
+     * @see #entriesToMap(Function)
      * @see Collectors#toMap(Function, Function, BinaryOperator)
+     * @since 0.7.3
      */
     public static <K, V, VV> Collector<Entry<K, V>, ?, Map<K, VV>> entriesToMap(
             Function<V, VV> valueMapper, BinaryOperator<VV> combiner) {
@@ -270,7 +286,12 @@ public final class MoreCollectors {
      * whose keys and values are taken from {@code Map.Entry}
      * @throws IllegalStateException if this stream contains duplicate keys
      *                               (according to {@link Object#equals(Object)})
+     *
+     * @see #entriesToCustomMap(Function, Supplier)
+     * @see #entriesToCustomMap(BinaryOperator, Supplier)
+     * @see #entriesToCustomMap(Function, BinaryOperator, Supplier)
      * @see Collectors#toMap(Function, Function, BinaryOperator, Supplier)
+     * @since 0.7.3
      */
     public static <K, V, M extends Map<K, V>> Collector<Entry<K, V>, ?, M> entriesToCustomMap(
             Supplier<M> mapSupplier) {
@@ -295,7 +316,11 @@ public final class MoreCollectors {
      * @throws IllegalStateException if this stream contains duplicate keys
      *                               (according to {@link Object#equals(Object)})
      *
+     * @see #entriesToCustomMap(Supplier)
+     * @see #entriesToCustomMap(BinaryOperator, Supplier)
+     * @see #entriesToCustomMap(Function, BinaryOperator, Supplier)
      * @see Collectors#toMap(Function, Function, BinaryOperator, Supplier)
+     * @since 0.7.3
      */
     public static <K, V, VV, M extends Map<K, VV>> Collector<Entry<K, V>, ?, M> entriesToCustomMap(
             Function<V, VV> valueMapper, Supplier<M> mapSupplier) {
@@ -325,7 +350,11 @@ public final class MoreCollectors {
      * whose keys and values are taken from {@code Map.Entry} and combining them
      * using the {@code combiner} function
      *
+     * @see #entriesToCustomMap(Supplier)
+     * @see #entriesToCustomMap(Function, Supplier)
+     * @see #entriesToCustomMap(Function, BinaryOperator, Supplier)
      * @see Collectors#toMap(Function, Function, BinaryOperator, Supplier)
+     * @since 0.7.3
      */
     public static <K, V, M extends Map<K, V>> Collector<Entry<K, V>, ?, M> entriesToCustomMap(
             BinaryOperator<V> combiner, Supplier<M> mapSupplier) {
@@ -357,7 +386,11 @@ public final class MoreCollectors {
      * whose keys and values are taken from {@code Map.Entry} and combining them
      * using the {@code combiner} function
      *
+     * @see #entriesToCustomMap(Supplier)
+     * @see #entriesToCustomMap(Function, Supplier)
+     * @see #entriesToCustomMap(BinaryOperator, Supplier)
      * @see Collectors#toMap(Function, Function, BinaryOperator, Supplier)
+     * @since 0.7.3
      */
     public static <K, V, VV, M extends Map<K, VV>> Collector<Entry<K, V>, ?, M> entriesToCustomMap(
             Function<V, VV> valueMapper, BinaryOperator<VV> combiner, Supplier<M> mapSupplier) {

--- a/src/main/java/one/util/streamex/MoreCollectors.java
+++ b/src/main/java/one/util/streamex/MoreCollectors.java
@@ -186,7 +186,7 @@ public final class MoreCollectors {
      * @see Collectors#toMap(Function, Function)
      * @since 0.7.3
      */
-    public static <K, V> Collector<Entry<K, V>, ?, Map<K, V>> entriesToMap() {
+    public static <K, V> Collector<Entry<? extends K, ? extends V>, ?, Map<K, V>> entriesToMap() {
         return Collectors.toMap(Entry::getKey, Entry::getValue);
     }
 
@@ -214,7 +214,8 @@ public final class MoreCollectors {
      * @see Collectors#toMap(Function, Function, BinaryOperator)
      * @since 0.7.3
      */
-    public static <K, V> Collector<Entry<K, V>, ?, Map<K, V>> entriesToMap(BinaryOperator<V> combiner) {
+    public static <K, V> Collector<Entry<? extends K, ? extends V>, ?, Map<K, V>> entriesToMap(
+            BinaryOperator<V> combiner) {
         return Collectors.toMap(Entry::getKey, Entry::getValue, combiner);
     }
 
@@ -240,7 +241,8 @@ public final class MoreCollectors {
      * @see Collectors#toMap(Function, Function)
      * @since 0.7.3
      */
-    public static <K, V, VV> Collector<Entry<K, V>, ?, Map<K, VV>> entriesToMap(Function<V, VV> valueMapper) {
+    public static <K, V, VV> Collector<Entry<? extends K, ? extends V>, ?, Map<K, VV>> entriesToMap(
+            Function<V, VV> valueMapper) {
         Objects.requireNonNull(valueMapper);
         return Collectors.toMap(Entry::getKey, entry -> valueMapper.apply(entry.getValue()));
     }
@@ -270,7 +272,7 @@ public final class MoreCollectors {
      * @see Collectors#toMap(Function, Function, BinaryOperator)
      * @since 0.7.3
      */
-    public static <K, V, VV> Collector<Entry<K, V>, ?, Map<K, VV>> entriesToMap(
+    public static <K, V, VV> Collector<Entry<? extends K, ? extends V>, ?, Map<K, VV>> entriesToMap(
             Function<V, VV> valueMapper, BinaryOperator<VV> combiner) {
         Objects.requireNonNull(valueMapper);
         return Collectors.toMap(Entry::getKey, entry -> valueMapper.apply(entry.getValue()), combiner);
@@ -296,7 +298,7 @@ public final class MoreCollectors {
      * @see Collectors#toMap(Function, Function, BinaryOperator, Supplier)
      * @since 0.7.3
      */
-    public static <K, V, M extends Map<K, V>> Collector<Entry<K, V>, ?, M> entriesToCustomMap(
+    public static <K, V, M extends Map<K, V>> Collector<Entry<? extends K, ? extends V>, ?, M> entriesToCustomMap(
             Supplier<M> mapSupplier) {
         return Collectors.toMap(Entry::getKey, Entry::getValue, throwingMerger(), mapSupplier);
     }
@@ -326,7 +328,7 @@ public final class MoreCollectors {
      * @see Collectors#toMap(Function, Function, BinaryOperator, Supplier)
      * @since 0.7.3
      */
-    public static <K, V, VV, M extends Map<K, VV>> Collector<Entry<K, V>, ?, M> entriesToCustomMap(
+    public static <K, V, VV, M extends Map<K, VV>> Collector<Entry<? extends K, ? extends V>, ?, M> entriesToCustomMap(
             Function<V, VV> valueMapper, Supplier<M> mapSupplier) {
         Objects.requireNonNull(valueMapper);
         return Collectors.toMap(Entry::getKey, entry -> valueMapper.apply(entry.getValue()), throwingMerger(), mapSupplier);
@@ -360,7 +362,7 @@ public final class MoreCollectors {
      * @see Collectors#toMap(Function, Function, BinaryOperator, Supplier)
      * @since 0.7.3
      */
-    public static <K, V, M extends Map<K, V>> Collector<Entry<K, V>, ?, M> entriesToCustomMap(
+    public static <K, V, M extends Map<K, V>> Collector<Entry<? extends K, ? extends V>, ?, M> entriesToCustomMap(
             BinaryOperator<V> combiner, Supplier<M> mapSupplier) {
         return Collectors.toMap(Entry::getKey, Entry::getValue, combiner, mapSupplier);
     }
@@ -397,7 +399,7 @@ public final class MoreCollectors {
      * @see Collectors#toMap(Function, Function, BinaryOperator, Supplier)
      * @since 0.7.3
      */
-    public static <K, V, VV, M extends Map<K, VV>> Collector<Entry<K, V>, ?, M> entriesToCustomMap(
+    public static <K, V, VV, M extends Map<K, VV>> Collector<Entry<? extends K, ? extends V>, ?, M> entriesToCustomMap(
             Function<V, VV> valueMapper, BinaryOperator<VV> combiner, Supplier<M> mapSupplier) {
         Objects.requireNonNull(valueMapper);
         return Collectors.toMap(Entry::getKey, entry -> valueMapper.apply(entry.getValue()), combiner, mapSupplier);

--- a/src/main/java/one/util/streamex/MoreCollectors.java
+++ b/src/main/java/one/util/streamex/MoreCollectors.java
@@ -168,18 +168,89 @@ public final class MoreCollectors {
         }, Function.identity(), set -> set.size() == size, UNORDERED_ID_CHARACTERISTICS);
     }
 
+    /**
+     * Returns a {@code Collector} that accumulates elements into a {@code Map}
+     * whose keys and values are taken from {@code Map.Entry}.
+     *
+     * @param  <K> the {@link Comparable} type of then map keys
+     * @param  <V> the type of the map values
+     *
+     * @return {@code Collector} which collects elements into a {@code Map}
+     * whose keys and values are taken from {@code Map.Entry}
+     * @throws IllegalStateException if this stream contains duplicate keys
+     *         (according to {@link Object#equals(Object)})
+     * @see Collectors#toMap(Function, Function)
+     */
     public static <K, V> Collector<Entry<K, V>, ?, Map<K, V>> entriesToMap() {
         return Collectors.toMap(Entry::getKey, Entry::getValue);
     }
 
+    /**
+     * Returns a {@code Collector} that accumulates elements into a {@code Map}
+     * whose keys and values are taken from {@code Map.Entry} and combining them
+     * using the provided {@code combiner} function to the input elements.
+     *
+     * <p>If the mapped keys contains duplicates (according to {@link Object#equals(Object)}),
+     * the value mapping function is applied to each equal element, and the
+     * results are merged using the provided {@code combiner} function.
+     *
+     * @param <K>      the {@link Comparable} type of then map keys
+     * @param <V>      the type of the map values
+     * @param combiner a merge function, used to resolve collisions between
+     *                 values associated with the same key, as supplied
+     *                 to {@link Map#merge(Object, Object, BiFunction)}
+     * @return {@code Collector} which collects elements into a {@code Map}
+     * whose keys and values are taken from {@code Map.Entry} and combining them
+     * using the {@code combiner} function
+     * @throws IllegalStateException if this stream contains duplicate keys
+     *                               (according to {@link Object#equals(Object)})
+     * @see Collectors#toMap(Function, Function, BinaryOperator)
+     */
     public static <K, V> Collector<Entry<K, V>, ?, Map<K, V>> entriesToMap(BinaryOperator<V> combiner) {
         return Collectors.toMap(Entry::getKey, Entry::getValue, combiner);
     }
 
+    /**
+     * Returns a {@code Collector} that accumulates elements into a {@code Map}
+     * whose keys are taken from {@code Map.Entry} and values are the result
+     * of applying the provided {@code valueMapper} function.
+     *
+     * @param <K>         the {@link Comparable} type of then map keys
+     * @param <V>         the type of the map values
+     * @param <VV>        the output type of the value mapping function
+     * @param valueMapper a mapping function to produce values from {@code Map.Entry} values
+     * @return {@code Collector} which collects elements into a {@code Map}
+     * whose keys are taken from {@code Map.Entry} and values are the result of applying
+     * the provided {@code valueMapper} function to {@code Map.Entry} values.
+     * @throws IllegalStateException if this stream contains duplicate keys
+     *                               (according to {@link Object#equals(Object)})
+     * @see Collectors#toMap(Function, Function)
+     */
     public static <K, V, VV> Collector<Entry<K, V>, ?, Map<K, VV>> entriesToMap(Function<V, VV> valueMapper) {
         return Collectors.toMap(Entry::getKey, entry -> valueMapper.apply(entry.getValue()));
     }
 
+    /**
+     * Returns a {@code Collector} that accumulates elements into a {@code Map}
+     * whose keys are taken from {@code Map.Entry} and values are the result
+     * of applying the provided {@code valueMapper} function and combining them
+     * using the provided {@code combiner} function to {@code Map.Entry} values of input elements.
+     *
+     * @param <K>         the {@link Comparable} type of then map keys
+     * @param <V>         the type of the map values
+     * @param <VV>        the output type of the value mapping function
+     * @param valueMapper a mapping function to produce values
+     * @param combiner    a merge function, used to resolve collisions between
+     *                    values associated with the same key, as supplied
+     *                    to {@link Map#merge(Object, Object, BiFunction)}
+     * @return {@code Collector} which collects elements into a {@code Map}
+     * whose keys are taken from {@code Map.Entry} and values are the result
+     * of applying the provided {@code valueMapper} function and combining
+     * them using the provided {@code combiner} function to the input elements.
+     * @throws IllegalStateException if this stream contains duplicate keys
+     *                               (according to {@link Object#equals(Object)})
+     * @see Collectors#toMap(Function, Function, BinaryOperator)
+     */
     public static <K, V, VV> Collector<Entry<K, V>, ?, Map<K, VV>> entriesToMap(
             Function<V, VV> valueMapper, BinaryOperator<VV> combiner) {
         Objects.requireNonNull(valueMapper);

--- a/src/main/java/one/util/streamex/MoreCollectors.java
+++ b/src/main/java/one/util/streamex/MoreCollectors.java
@@ -168,18 +168,15 @@ public final class MoreCollectors {
         }, Function.identity(), set -> set.size() == size, UNORDERED_ID_CHARACTERISTICS);
     }
 
-
     public static <K, V> Collector<Entry<K, V>, ?, Map<K, V>> entriesToMap() {
         return Collectors.toMap(Entry::getKey, Entry::getValue);
     }
 
-    public static <K, V> Collector<Entry<K, V>, ?, Map<K, V>> entriesToMap(
-            BinaryOperator<V> combiner) {
+    public static <K, V> Collector<Entry<K, V>, ?, Map<K, V>> entriesToMap(BinaryOperator<V> combiner) {
         return Collectors.toMap(Entry::getKey, Entry::getValue, combiner);
     }
 
-    public static <K, V, VV> Collector<Entry<K, V>, ?, Map<K, VV>> entriesToMap(
-            Function<V, VV> valueMapper) {
+    public static <K, V, VV> Collector<Entry<K, V>, ?, Map<K, VV>> entriesToMap(Function<V, VV> valueMapper) {
         return Collectors.toMap(Entry::getKey, entry -> valueMapper.apply(entry.getValue()));
     }
 
@@ -207,7 +204,6 @@ public final class MoreCollectors {
 
     public static <K, V, VV, M extends Map<K, VV>> Collector<Entry<K, V>, ?, M> entriesToCustomMap(
             Function<V, VV> valueMapper, BinaryOperator<VV> combiner, Supplier<M> mapSupplier) {
-
         Objects.requireNonNull(valueMapper);
         return Collectors.toMap(Entry::getKey, entry -> valueMapper.apply(entry.getValue()), combiner, mapSupplier);
     }

--- a/src/main/java/one/util/streamex/MoreCollectors.java
+++ b/src/main/java/one/util/streamex/MoreCollectors.java
@@ -178,7 +178,7 @@ public final class MoreCollectors {
      * @return {@code Collector} which collects elements into a {@code Map}
      * whose keys and values are taken from {@code Map.Entry}
      * @throws IllegalStateException if this stream contains duplicate keys
-     *         (according to {@link Object#equals(Object)})
+     *         (according to {@link Object#equals(Object)}).
      *
      * @see #entriesToMap(BinaryOperator)
      * @see #entriesToMap(Function)
@@ -231,7 +231,8 @@ public final class MoreCollectors {
      * whose keys are taken from {@code Map.Entry} and values are the result of applying
      * the provided {@code valueMapper} function to {@code Map.Entry} values.
      * @throws IllegalStateException if this stream contains duplicate keys
-     *                               (according to {@link Object#equals(Object)})
+     *                               (according to {@link Object#equals(Object)}).
+     * @throws NullPointerException if mapper is null.
      *
      * @see #entriesToMap()
      * @see #entriesToMap(BinaryOperator)
@@ -240,6 +241,7 @@ public final class MoreCollectors {
      * @since 0.7.3
      */
     public static <K, V, VV> Collector<Entry<K, V>, ?, Map<K, VV>> entriesToMap(Function<V, VV> valueMapper) {
+        Objects.requireNonNull(valueMapper);
         return Collectors.toMap(Entry::getKey, entry -> valueMapper.apply(entry.getValue()));
     }
 
@@ -260,6 +262,7 @@ public final class MoreCollectors {
      * whose keys are taken from {@code Map.Entry} and values are the result
      * of applying the provided {@code valueMapper} function and combining
      * them using the provided {@code combiner} function.
+     * @throws NullPointerException if mapper is null.
      *
      * @see #entriesToMap()
      * @see #entriesToMap(BinaryOperator)
@@ -285,7 +288,7 @@ public final class MoreCollectors {
      * defined by {@code mapSupplier} function
      * whose keys and values are taken from {@code Map.Entry}
      * @throws IllegalStateException if this stream contains duplicate keys
-     *                               (according to {@link Object#equals(Object)})
+     *                               (according to {@link Object#equals(Object)}).
      *
      * @see #entriesToCustomMap(Function, Supplier)
      * @see #entriesToCustomMap(BinaryOperator, Supplier)
@@ -314,7 +317,8 @@ public final class MoreCollectors {
      * from {@code Map.Entry} and values are the result of applying
      * the provided {@code valueMapper} function to {@code Map.Entry} values.
      * @throws IllegalStateException if this stream contains duplicate keys
-     *                               (according to {@link Object#equals(Object)})
+     *                               (according to {@link Object#equals(Object)}).
+     * @throws NullPointerException if mapper is null.
      *
      * @see #entriesToCustomMap(Supplier)
      * @see #entriesToCustomMap(BinaryOperator, Supplier)
@@ -385,6 +389,7 @@ public final class MoreCollectors {
      * @return {@code Collector} which collects elements into a {@code Map}
      * whose keys and values are taken from {@code Map.Entry} and combining them
      * using the {@code combiner} function
+     * @throws NullPointerException if mapper is null.
      *
      * @see #entriesToCustomMap(Supplier)
      * @see #entriesToCustomMap(Function, Supplier)

--- a/src/main/java/one/util/streamex/MoreCollectors.java
+++ b/src/main/java/one/util/streamex/MoreCollectors.java
@@ -170,53 +170,50 @@ public final class MoreCollectors {
     }
 
 
-    public static <K, V> Collector<Entry<K, V>, ?, Map<K, V>> toMap() {
+    public static <K, V> Collector<Entry<K, V>, ?, Map<K, V>> entriesToMap() {
         return Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue);
     }
 
-    public static <K, V> Collector<Entry<K, V>, ?, ConcurrentMap<K, V>> toConcurrentMap() {
-        return Collectors.toConcurrentMap(Map.Entry::getKey, Map.Entry::getValue);
-    }
-
-    public static <K, V> Collector<Entry<K, V>, ?, Map<K, V>> toMap(
+    public static <K, V> Collector<Entry<K, V>, ?, Map<K, V>> entriesToMap(
             BinaryOperator<V> combiner) {
 
         return Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, combiner);
     }
 
-    public static <K, V, VV> Collector<Entry<K, V>, ?, Map<K, VV>> toMap(
+    public static <K, V, VV> Collector<Entry<K, V>, ?, Map<K, VV>> entriesToMap(
             Function<V, VV> valueMapper) {
 
         return null;
     }
 
-    public static <K, V, VV> Collector<Entry<K, V>, ?, Map<K, VV>> toMap(
+    public static <K, V, VV> Collector<Entry<K, V>, ?, Map<K, VV>> entriesToMap(
             Function<V, VV> valueMapper, BinaryOperator<VV> combiner) {
 
         Objects.requireNonNull(valueMapper);
         return null;
     }
 
-    public static <K, V, M extends Map<K, V>> Collector<Entry<K, V>, ?, M> toCustomMap(
+    public static <K, V, M extends Map<K, V>> Collector<Entry<K, V>, ?, M> entriesToCustomMap(
             Supplier<M> mapSupplier) {
 
         return null;
     }
 
-    public static <K, V, VV, M extends Map<K, VV>> Collector<Entry<K, V>, ?, M> toCustomMap(
+    public static <K, V, VV, M extends Map<K, VV>> Collector<Entry<K, V>, ?, M> entriesToCustomMap(
+
             Function<V, VV> valueMapper, Supplier<M> mapSupplier) {
 
         Objects.requireNonNull(valueMapper);
         return null;
     }
 
-    public static <K, V, M extends Map<K, V>> Collector<Entry<K, V>, ?, M> toCustomMap(
+    public static <K, V, M extends Map<K, V>> Collector<Entry<K, V>, ?, M> entriesToCustomMap(
             BinaryOperator<V> combiner, Supplier<M> mapSupplier) {
 
         return null;
     }
 
-    public static <K, V, VV, M extends Map<K, VV>> Collector<Entry<K, V>, ?, M> toCustomMap(
+    public static <K, V, VV, M extends Map<K, VV>> Collector<Entry<K, V>, ?, M> entriesToCustomMap(
             Function<V, VV> valueMapper, BinaryOperator<VV> combiner, Supplier<M> mapSupplier) {
 
         Objects.requireNonNull(valueMapper);

--- a/src/main/java/one/util/streamex/MoreCollectors.java
+++ b/src/main/java/one/util/streamex/MoreCollectors.java
@@ -187,7 +187,6 @@ public final class MoreCollectors {
      * @throws IllegalStateException if this stream contains duplicate keys
      *                               (according to {@link Object#equals(Object)}).
      * @see #entriesToMap(BinaryOperator)
-     * @see #entriesToMap(Function, BinaryOperator)
      * @see Collectors#toMap(Function, Function)
      * @since 0.7.3
      */
@@ -221,44 +220,12 @@ public final class MoreCollectors {
      * using the {@code combiner} function
      * @throws NullPointerException if combiner is null.
      * @see #entriesToMap()
-     * @see #entriesToMap(Function, BinaryOperator)
      * @see Collectors#toMap(Function, Function, BinaryOperator)
      * @since 0.7.3
      */
     public static <K, V> Collector<Entry<? extends K, ? extends V>, ?, Map<K, V>> entriesToMap(
             BinaryOperator<V> combiner) {
         return entriesToCustomMap(combiner, HashMap::new);
-    }
-
-    /**
-     * Returns a {@code Collector} that accumulates input elements into a {@code Map}
-     * whose keys are taken from {@code Map.Entry} and values are the result
-     * of applying the provided {@code valueMapper} function to {@code Map.Entry} values
-     * and combining them using the provided {@code combiner} function.
-     *
-     * @param <K>         the type of the map keys
-     * @param <V>         the type of the map values
-     * @param <VV>        the output type of the value mapping function
-     * @param valueMapper a mapping function to produce values
-     * @param combiner    a merge function, used to resolve collisions between
-     *                    values associated with the same key, as supplied
-     *                    to {@link Map#merge(Object, Object, BiFunction)}
-     * @return {@code Collector} which collects elements into a {@code Map}
-     * whose keys are taken from {@code Map.Entry} and values are the result
-     * of applying the provided {@code valueMapper} function and combining
-     * them using the provided {@code combiner} function.
-     * @throws NullPointerException if mapper is null.
-     * @throws NullPointerException if combiner is null.
-     * @see #entriesToMap()
-     * @see #entriesToMap(BinaryOperator)
-     * @see Collectors#toMap(Function, Function, BinaryOperator)
-     * @since 0.7.3
-     */
-    public static <K, V, VV> Collector<Entry<? extends K, ? extends V>, ?, Map<K, VV>> entriesToMap(
-            Function<V, VV> valueMapper, BinaryOperator<VV> combiner) {
-        Objects.requireNonNull(valueMapper);
-        Objects.requireNonNull(combiner);
-        return Collectors.toMap(Entry::getKey, entry -> valueMapper.apply(entry.getValue()), combiner);
     }
 
     /**
@@ -277,8 +244,7 @@ public final class MoreCollectors {
      * @throws NullPointerException  if mapSupplier is null.
      * @throws NullPointerException  if entry value is null.
      * @see #entriesToCustomMap(BinaryOperator, Supplier)
-     * @see #entriesToCustomMap(Function, BinaryOperator, Supplier)
-     * @see Collectors#toMap(Function, Function, BinaryOperator, Supplier)
+     * @see Collector#of(Supplier, BiConsumer, BinaryOperator, Collector.Characteristics...)
      * @since 0.7.3
      */
     public static <K, V, M extends Map<K, V>> Collector<Entry<? extends K, ? extends V>, ?, M> entriesToCustomMap(
@@ -316,7 +282,6 @@ public final class MoreCollectors {
      * @throws NullPointerException if {@code combiner} is null.
      * @throws NullPointerException if {@code mapSupplier} is null.
      * @see #entriesToCustomMap(Supplier)
-     * @see #entriesToCustomMap(Function, BinaryOperator, Supplier)
      * @see Collectors#toMap(Function, Function, BinaryOperator, Supplier)
      * @since 0.7.3
      */
@@ -325,46 +290,6 @@ public final class MoreCollectors {
         Objects.requireNonNull(combiner);
         Objects.requireNonNull(mapSupplier);
         return Collectors.toMap(Entry::getKey, Entry::getValue, combiner, mapSupplier);
-    }
-
-    /**
-     * Returns a {@code Collector} that accumulates elements into
-     * a result {@code Map} defined by {@code mapSupplier} function
-     * whose keys are taken from {@code Map.Entry} and values are the result
-     * of applying the provided {@code valueMapper} function to {@code Map.Entry} values
-     * and combining them using the provided {@code combiner} function.
-     *
-     * <p>If the mapped keys contains duplicates (according to {@link Object#equals(Object)}),
-     * the value mapping function is applied to each equal element, and the
-     * results are merged using the provided {@code combiner} function.
-     *
-     * @param <K>         the type of the map keys
-     * @param <V>         the type of the map values
-     * @param <VV>        the output type of the value mapping function
-     * @param <M>         the type of the resulting {@code Map}
-     * @param valueMapper a mapping function to produce values
-     * @param combiner    a merge function, used to resolve collisions between
-     *                    values associated with the same key, as supplied
-     *                    to {@link Map#merge(Object, Object, BiFunction)}
-     * @param mapSupplier a function which returns a new, empty {@code Map} into
-     *                    which the results will be inserted
-     * @return {@code Collector} which collects elements into a {@code Map}
-     * whose keys and values are taken from {@code Map.Entry} and combining them
-     * using the {@code combiner} function
-     * @throws NullPointerException if {@code }valueMapper} is null.
-     * @throws NullPointerException if {@code combiner} is null.
-     * @throws NullPointerException if {@code mapSupplier} is null.
-     * @see #entriesToCustomMap(Supplier)
-     * @see #entriesToCustomMap(BinaryOperator, Supplier)
-     * @see Collectors#toMap(Function, Function, BinaryOperator, Supplier)
-     * @since 0.7.3
-     */
-    public static <K, V, VV, M extends Map<K, VV>> Collector<Entry<? extends K, ? extends V>, ?, M> entriesToCustomMap(
-            Function<V, VV> valueMapper, BinaryOperator<VV> combiner, Supplier<M> mapSupplier) {
-        Objects.requireNonNull(valueMapper);
-        Objects.requireNonNull(combiner);
-        Objects.requireNonNull(mapSupplier);
-        return Collectors.toMap(Entry::getKey, entry -> valueMapper.apply(entry.getValue()), combiner, mapSupplier);
     }
 
     /**

--- a/src/main/java/one/util/streamex/MoreCollectors.java
+++ b/src/main/java/one/util/streamex/MoreCollectors.java
@@ -486,9 +486,7 @@ public final class MoreCollectors {
 
         Supplier<PairBox<A1, A2>> supplier = () -> new PairBox<>(c1Supplier.get(), c2Supplier.get());
         BiConsumer<PairBox<A1, A2>, T> accumulator = (acc, v) -> {
-
-
-
+            c1Accumulator.accept(acc.a, v);
             c2Accumulator.accept(acc.b, v);
         };
         BinaryOperator<PairBox<A1, A2>> combiner = (acc1, acc2) -> {

--- a/src/main/java/one/util/streamex/MoreCollectors.java
+++ b/src/main/java/one/util/streamex/MoreCollectors.java
@@ -34,7 +34,6 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
-import java.util.concurrent.ConcurrentMap;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
@@ -171,55 +170,53 @@ public final class MoreCollectors {
 
 
     public static <K, V> Collector<Entry<K, V>, ?, Map<K, V>> entriesToMap() {
-        return Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue);
+        return Collectors.toMap(Entry::getKey, Entry::getValue);
     }
 
     public static <K, V> Collector<Entry<K, V>, ?, Map<K, V>> entriesToMap(
             BinaryOperator<V> combiner) {
-
-        return Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, combiner);
+        return Collectors.toMap(Entry::getKey, Entry::getValue, combiner);
     }
 
     public static <K, V, VV> Collector<Entry<K, V>, ?, Map<K, VV>> entriesToMap(
             Function<V, VV> valueMapper) {
-
-        return null;
+        return Collectors.toMap(Entry::getKey, entry -> valueMapper.apply(entry.getValue()));
     }
 
     public static <K, V, VV> Collector<Entry<K, V>, ?, Map<K, VV>> entriesToMap(
             Function<V, VV> valueMapper, BinaryOperator<VV> combiner) {
-
         Objects.requireNonNull(valueMapper);
-        return null;
+        return Collectors.toMap(Entry::getKey, entry -> valueMapper.apply(entry.getValue()), combiner);
     }
 
     public static <K, V, M extends Map<K, V>> Collector<Entry<K, V>, ?, M> entriesToCustomMap(
             Supplier<M> mapSupplier) {
-
-        return null;
+        return Collectors.toMap(Entry::getKey, Entry::getValue, throwingMerger(), mapSupplier);
     }
 
     public static <K, V, VV, M extends Map<K, VV>> Collector<Entry<K, V>, ?, M> entriesToCustomMap(
-
             Function<V, VV> valueMapper, Supplier<M> mapSupplier) {
-
         Objects.requireNonNull(valueMapper);
-        return null;
+        return Collectors.toMap(Entry::getKey, entry -> valueMapper.apply(entry.getValue()), throwingMerger(), mapSupplier);
     }
 
     public static <K, V, M extends Map<K, V>> Collector<Entry<K, V>, ?, M> entriesToCustomMap(
             BinaryOperator<V> combiner, Supplier<M> mapSupplier) {
-
-        return null;
+        return Collectors.toMap(Entry::getKey, Entry::getValue, combiner, mapSupplier);
     }
 
     public static <K, V, VV, M extends Map<K, VV>> Collector<Entry<K, V>, ?, M> entriesToCustomMap(
             Function<V, VV> valueMapper, BinaryOperator<VV> combiner, Supplier<M> mapSupplier) {
 
         Objects.requireNonNull(valueMapper);
-        return null;
+        return Collectors.toMap(Entry::getKey, entry -> valueMapper.apply(entry.getValue()), combiner, mapSupplier);
     }
 
+    private static <T> BinaryOperator<T> throwingMerger() {
+        return (firstKey, secondKey) -> {
+            throw new IllegalStateException("Duplicate entry keys are not allowed (attempt to merge key '" + firstKey + "'). ");
+        };
+    }
 
     /**
      * Returns a {@code Collector} which counts a number of distinct values the

--- a/src/test/java/one/util/streamex/MoreCollectorsTest.java
+++ b/src/test/java/one/util/streamex/MoreCollectorsTest.java
@@ -647,6 +647,18 @@ public class MoreCollectorsTest {
     }
 
     @Test
+    public void testEntriesToMapWithValueMapper() {
+        streamEx(() -> EntryStream.of(1, "one", 2, "two", 3, "three", 4, "four"),
+                supplier -> {
+            Map<Integer, String> result = supplier.get().collect(MoreCollectors.entriesToMap((value) -> "See #" + value));
+            assertEquals("See #one", result.get(1));
+            assertEquals("See #two", result.get(2));
+            assertEquals("See #three", result.get(3));
+            assertEquals("See #four", result.get(4));
+        });
+    }
+
+    @Test
     public void testFlatMapping() {
         assertThrows(NullPointerException.class, () -> MoreCollectors.flatMapping(null));
         assertThrows(NullPointerException.class, () -> MoreCollectors.flatMapping(null, Collectors.toList()));

--- a/src/test/java/one/util/streamex/MoreCollectorsTest.java
+++ b/src/test/java/one/util/streamex/MoreCollectorsTest.java
@@ -600,16 +600,49 @@ public class MoreCollectorsTest {
 
         checkCollectorEmpty("entriesToMap", Collections.emptyMap(), MoreCollectors.entriesToMap());
 
-        Map<Integer, String> expected = EntryStream.of(1, "*", 2, "**", 3, "***", 4, "****", 5, "*****").toMap();
+        {
+            Map<Integer, String> expected = EntryStream.of(1, "*", 2, "**", 3, "***", 4, "****", 5, "*****").toMap();
+            Supplier<Stream<Entry<Integer, String>>> stream = expected.entrySet()::stream;
+            checkCollector("entriesToMap", expected, stream, MoreCollectors.entriesToMap());
 
-        checkCollector("entriesToMap", expected, expected.entrySet()::stream, MoreCollectors.entriesToMap());
-        streamEx(expected.entrySet()::stream, supplier -> {
-            Map<Integer, String> result = supplier.get().collect(MoreCollectors.entriesToMap());
-            assertEquals("*", result.get(1));
-            assertEquals("**", result.get(2));
+            streamEx(stream, supplier -> {
+                Map<Integer, String> result = supplier.get().collect(MoreCollectors.entriesToMap());
+                assertEquals("*", result.get(1));
+                assertEquals("**", result.get(2));
+                assertEquals("***", result.get(3));
+                assertEquals("****", result.get(4));
+                assertEquals("*****", result.get(5));
+            });
+        }
+    }
+
+    @Test
+    public void testEntriesToMapWithCombiner() {
+        streamEx(() -> Stream.of(
+                EntryStream.of(1, "*").toMap(),
+                EntryStream.of(1, "*", 2, "*").toMap(),
+                EntryStream.of(1, "*", 2, "*", 3, "*").toMap(),
+                EntryStream.of(1, "*", 2, "*", 3, "*", 4, "*").toMap(),
+                EntryStream.of(1, "*", 2, "*", 3, "*", 4, "*", 5, "*").toMap())
+                .flatMap(map -> map.entrySet().stream()), supplier -> {
+            Map<Integer, String> result = supplier.get().collect(MoreCollectors.entriesToMap(String::concat));
+            assertEquals("*****", result.get(1));
+            assertEquals("****", result.get(2));
             assertEquals("***", result.get(3));
-            assertEquals("****", result.get(4));
-            assertEquals("*****", result.get(5));
+            assertEquals("**", result.get(4));
+            assertEquals("*", result.get(5));
+        });
+
+        streamEx(() -> Stream.of(
+                EntryStream.of(1, "one", 2, "two", 3, "three", 4, "four").toMap(),
+                EntryStream.of(1, "ein", 2, "zwei", 3, "drei").toMap(),
+                EntryStream.of(1, "une", 2, "deux").toMap())
+                .flatMap(map -> map.entrySet().stream()), supplier -> {
+            Map<Integer, String> result = supplier.get().collect(MoreCollectors.entriesToMap((left, right) -> left + "," + right));
+            assertEquals("one,ein,une", result.get(1));
+            assertEquals("two,zwei,deux", result.get(2));
+            assertEquals("three,drei", result.get(3));
+            assertEquals("four", result.get(4));
         });
     }
 

--- a/src/test/java/one/util/streamex/MoreCollectorsTest.java
+++ b/src/test/java/one/util/streamex/MoreCollectorsTest.java
@@ -625,39 +625,6 @@ public class MoreCollectorsTest {
         }
     }
 
-
-    /**
-     * See {@link MoreCollectors#entriesToMap(Function)}.
-     */
-    @Test
-    public void testEntriesToMapWithValueMapper() {
-        Function<String, String> nullValueMapper = null;
-        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToMap(nullValueMapper));
-        assertThrows(IllegalStateException.class, () -> EntryStream.generate(() -> "a", () -> 1).limit(10)
-                .collect(MoreCollectors.entriesToMap((value) -> "['" + value + "']")));
-
-        checkCollectorEmpty("entriesToMap", Collections.emptyMap(), MoreCollectors.entriesToMap((a, b) -> a));
-
-        streamEx(() -> EntryStream.of(1, "one", 2, "two", 3, "three", 4, "four"),
-                supplier -> {
-                    Map<Integer, CharSequence> result = supplier.get().collect(MoreCollectors.entriesToMap((value) -> "See #" + value));
-                    assertEquals("See #one", result.get(1));
-                    assertEquals("See #two", result.get(2));
-                    assertEquals("See #three", result.get(3));
-                    assertEquals("See #four", result.get(4));
-                });
-
-        streamEx(() -> StreamEx.of("Bran Stark", "Arya Stark", "Jon Snow", "Tyrion (The Imp) Lannister", "Theon Greyjoy",
-                "Ser Jaime (The Kingslayer) Lannister", "Daenerys Stormborn Targaryen", "Khal Drogo", "Ser Jorah Mormont")
-                .mapToEntry(name -> name.contains("Khal") || name.contains("Ser")), supplier -> {
-            Map<String, String> result = supplier.get().collect(
-                    MoreCollectors.entriesToMap((value) -> value ? "This character has celebrity title" : "Standard character"));
-            assertEquals("This character has celebrity title", result.get("Khal Drogo"));
-            assertEquals("Standard character", result.get("Jon Snow"));
-            assertEquals("This character has celebrity title", result.get("Ser Jorah Mormont"));
-        });
-    }
-
     /**
      * See {@link MoreCollectors#entriesToMap(BinaryOperator)}.
      */
@@ -776,32 +743,6 @@ public class MoreCollectorsTest {
                     .collect(MoreCollectors.entriesToCustomMap(LinkedHashMap::new));
             assertEquals("5=*****", expected.entrySet().iterator().next().toString());
         }
-    }
-
-    /**
-     * See {@link MoreCollectors#entriesToCustomMap(Function, Supplier)}.
-     */
-    @Test
-    public void testEntriesToCustomMapWithValueMapper() {
-        Function<String, String> nullValueMapper = null;
-        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToCustomMap(nullValueMapper, LinkedHashMap::new));
-        assertThrows(IllegalStateException.class, () -> EntryStream.generate(() -> "a", () -> 1).limit(10)
-                .collect(MoreCollectors.entriesToCustomMap((value) -> "['" + value + "']", LinkedHashMap::new)));
-
-        checkCollectorEmpty("entriesToMap", Collections.emptyMap(), MoreCollectors.entriesToCustomMap((a, b) -> a, TreeMap::new));
-
-        streamEx(() -> EntryStream.of(5, "*****", 1, "*", 4, "****", 2, "**", 3, "***"), supplier -> {
-            NavigableMap<Integer, String> result = supplier.get().collect(
-                    MoreCollectors.entriesToCustomMap((value) -> "['" + value + "']", TreeMap::new));
-            assertEquals("1=['*']", result.firstEntry().toString());
-            assertEquals("5=['*****']", result.lastEntry().toString());
-        });
-
-        streamEx(() -> EntryStream.of(5, "*****", 1, "*", 4, "****", 2, "**", 3, "***"), supplier -> {
-            Map<Integer, String> result = supplier.get().collect(
-                    MoreCollectors.entriesToCustomMap((value) -> "['" + value + "']", LinkedHashMap::new));
-            assertEquals("5=['*****']", result.entrySet().iterator().next().toString());
-        });
     }
 
     /**

--- a/src/test/java/one/util/streamex/MoreCollectorsTest.java
+++ b/src/test/java/one/util/streamex/MoreCollectorsTest.java
@@ -57,6 +57,7 @@ import static java.util.Arrays.asList;
 import static one.util.streamex.TestHelpers.assertThrows;
 import static one.util.streamex.TestHelpers.checkCollector;
 import static one.util.streamex.TestHelpers.checkCollectorEmpty;
+import static one.util.streamex.TestHelpers.checkIllegalStateException;
 import static one.util.streamex.TestHelpers.checkShortCircuitCollector;
 import static one.util.streamex.TestHelpers.streamEx;
 import static one.util.streamex.TestHelpers.withRandom;
@@ -697,8 +698,14 @@ public class MoreCollectorsTest {
      */
     @Test
     public void testEntriesToCustomMap() {
+        assertThrows(NullPointerException.class, () ->
+                EntryStream.of("a", "*", "b", null).collect(MoreCollectors.entriesToCustomMap(LinkedHashMap::new)));
+
         assertThrows(IllegalStateException.class, () ->
                 EntryStream.generate(() -> "a", () -> 1).limit(10).collect(MoreCollectors.entriesToCustomMap(LinkedHashMap::new)));
+        streamEx(() -> EntryStream.of("a", "*", "a", "**").stream(), supplier -> {
+            checkIllegalStateException(() -> supplier.get().collect(MoreCollectors.entriesToCustomMap(TreeMap::new)), "a", "*", "**");
+        });
 
         checkCollectorEmpty("entriesToMap", Collections.emptyMap(),
                 MoreCollectors.entriesToCustomMap(HashMap::new));

--- a/src/test/java/one/util/streamex/MoreCollectorsTest.java
+++ b/src/test/java/one/util/streamex/MoreCollectorsTest.java
@@ -33,8 +33,6 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.TreeMap;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -594,62 +592,25 @@ public class MoreCollectorsTest {
     }
 
     @Test
-    public void testToMap() {
+    public void testEntriesToMap() {
         assertThrows(IllegalStateException.class, () ->
-                EntryStream.generate(() -> "a", () -> 1).limit(10).collect(MoreCollectors.toMap()));
+                EntryStream.generate(() -> "a", () -> 1).limit(10).collect(MoreCollectors.entriesToMap()));
 
-        assertThrows(NullPointerException.class, () -> MoreCollectors.toMap(null, null));
+        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToMap(null, null));
 
-        {
-            Map<Integer, String> expected = EntryStream.of(1, "*", 2, "**", 3, "***", 4, "****")
-                    .collect(MoreCollectors.toMap());
-            checkCollector("toMap", expected, expected.entrySet()::stream, MoreCollectors.toMap());
-        }
+        checkCollectorEmpty("entriesToMap", Collections.emptyMap(), MoreCollectors.entriesToMap());
 
-        final Map<Integer, String> expected = new HashMap<>();
-        expected.put(1, "one");
-        expected.put(2, "two");
-        expected.put(3, "three");
-        expected.put(4, "four");
-        expected.put(5, "five");
+        Map<Integer, String> expected = EntryStream.of(1, "*", 2, "**", 3, "***", 4, "****", 5, "*****").toMap();
 
-        checkCollector("toMap", expected, expected.entrySet()::stream, MoreCollectors.toMap());
+        checkCollector("entriesToMap", expected, expected.entrySet()::stream, MoreCollectors.entriesToMap());
         streamEx(expected.entrySet()::stream, supplier -> {
-            Map<Integer, String> result = supplier.get().collect(MoreCollectors.toMap());
-            assertEquals("one", result.get(1));
-            assertEquals("two", result.get(2));
-            assertEquals("three", result.get(3));
-            assertEquals("four", result.get(4));
-            assertEquals("five", result.get(5));
-        });
-
-        checkCollectorEmpty("Empty", Collections.emptyMap(), MoreCollectors.toMap());
-
-        /*streamEx(EntryStream.of(1, "*", 2, "**", 3, "***", 4, "****")::stream, supplier -> {
-            Map<Integer, String> result = supplier.get().collect(MoreCollectors.toMap());
+            Map<Integer, String> result = supplier.get().collect(MoreCollectors.entriesToMap());
             assertEquals("*", result.get(1));
             assertEquals("**", result.get(2));
             assertEquals("***", result.get(3));
             assertEquals("****", result.get(4));
-        });*/
-    }
-
-    @Test
-    public void toConcurrentMap() {
-        final ConcurrentMap<Integer, String> expected = new ConcurrentHashMap<>();
-        expected.put(0, "zero");
-        expected.put(1, "one");
-        expected.put(2, "two");
-        expected.put(3, "three");
-        expected.put(4, "four");
-        expected.put(5, "five");
-        expected.put(6, "six");
-        expected.put(7, "seven");
-        expected.put(8, "eight");
-        expected.put(9, "nine");
-        expected.put(10, "ten");
-        checkCollector("toConcurrentMap", expected, expected.entrySet()::stream,
-                MoreCollectors.toConcurrentMap());
+            assertEquals("*****", result.get(5));
+        });
     }
 
     @Test

--- a/src/test/java/one/util/streamex/MoreCollectorsTest.java
+++ b/src/test/java/one/util/streamex/MoreCollectorsTest.java
@@ -37,6 +37,7 @@ import java.util.OptionalLong;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
@@ -593,6 +594,9 @@ public class MoreCollectorsTest {
         checkCollectorEmpty("Empty", EnumSet.noneOf(TimeUnit.class), MoreCollectors.toEnumSet(TimeUnit.class));
     }
 
+    /**
+     * See {@link MoreCollectors#entriesToMap()}.
+     */
     @Test
     public void testEntriesToMap() {
         assertThrows(IllegalStateException.class, () ->
@@ -616,6 +620,9 @@ public class MoreCollectorsTest {
         }
     }
 
+    /**
+     * See {@link MoreCollectors#entriesToMap(BinaryOperator)}.
+     */
     @Test
     public void testEntriesToMapWithCombiner() {
         streamEx(() -> Stream.of(
@@ -646,6 +653,9 @@ public class MoreCollectorsTest {
         });
     }
 
+    /**
+     * See {@link MoreCollectors#entriesToMap(Function)}.
+     */
     @Test
     public void testEntriesToMapWithValueMapper() {
         streamEx(() -> EntryStream.of(1, "one", 2, "two", 3, "three", 4, "four"),
@@ -668,6 +678,9 @@ public class MoreCollectorsTest {
         });
     }
 
+    /**
+     * See {@link MoreCollectors#entriesToMap(Function, BinaryOperator)}.
+     */
     @Test
     public void testEntriesToMapWithValueMapperAndCombiner() {
         assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToMap(null, null));
@@ -686,6 +699,9 @@ public class MoreCollectorsTest {
         });
     }
 
+    /**
+     * See {@link MoreCollectors#entriesToCustomMap(Supplier)}.
+     */
     @Test
     public void testEntriesToCustomMap() {
         assertThrows(IllegalStateException.class, () ->
@@ -729,6 +745,9 @@ public class MoreCollectorsTest {
         }
     }
 
+    /**
+     * See {@link MoreCollectors#entriesToCustomMap(Function, Supplier)}.
+     */
     @Test
     public void testEntriesToCustomMapWithValueMapper() {
         assertThrows(IllegalStateException.class, () ->
@@ -749,6 +768,9 @@ public class MoreCollectorsTest {
         });
     }
 
+    /**
+     * See {@link MoreCollectors#entriesToCustomMap(BinaryOperator, Supplier)}.
+     */
     @Test
     public void testEntriesToCustomMapWithCombiner() {
         streamEx(() -> Stream.of(
@@ -783,6 +805,9 @@ public class MoreCollectorsTest {
         });
     }
 
+    /**
+     * See {@link MoreCollectors#entriesToCustomMap(Function, BinaryOperator, Supplier)}.
+     */
     @Test
     public void testEntriesToCustomMapWithValueMapperAndCombiner() {
         assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToCustomMap(null, null, null));

--- a/src/test/java/one/util/streamex/MoreCollectorsTest.java
+++ b/src/test/java/one/util/streamex/MoreCollectorsTest.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -655,6 +656,22 @@ public class MoreCollectorsTest {
             assertEquals("See #two", result.get(2));
             assertEquals("See #three", result.get(3));
             assertEquals("See #four", result.get(4));
+        });
+    }
+
+    @Test
+    public void testEntriesToMapWithValueMapperAndCombiner() {
+        streamEx(() -> Stream.of(
+                EntryStream.of(1, "one", 2, "two", 3, "three", 4, "four").toMap(),
+                EntryStream.of(1, "ein", 2, "zwei", 3, "drei").toMap(),
+                EntryStream.of(1, "une", 2, "deux").toMap())
+                .flatMap(map -> map.entrySet().stream()), supplier -> {
+            Map<Integer, String> result = supplier.get().collect(
+                    MoreCollectors.entriesToMap((value) -> "['" + value + "']", (left, right) -> left + ", " + right));
+            assertEquals("['one'], ['ein'], ['une']", result.get(1));
+            assertEquals("['two'], ['zwei'], ['deux']", result.get(2));
+            assertEquals("['three'], ['drei']", result.get(3));
+            assertEquals("['four']", result.get(4));
         });
     }
 

--- a/src/test/java/one/util/streamex/MoreCollectorsTest.java
+++ b/src/test/java/one/util/streamex/MoreCollectorsTest.java
@@ -33,7 +33,6 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.TreeMap;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -656,6 +655,18 @@ public class MoreCollectorsTest {
             assertEquals("See #two", result.get(2));
             assertEquals("See #three", result.get(3));
             assertEquals("See #four", result.get(4));
+        });
+
+        streamEx(() -> StreamEx.of("Bran Stark", "Arya Stark", "Jon Snow", "Tyrion (The Imp) Lannister", "Theon Greyjoy",
+                "Ser Jaime (The Kingslayer) Lannister", "Daenerys Stormborn Targaryen", "Khal Drogo", "Ser Jorah Mormont")
+                .mapToEntry(name -> name.contains("Khal") || name.contains("Ser")), supplier -> {
+            Map<String, String> result = supplier.get().collect(
+                    MoreCollectors.entriesToMap((value) -> {
+                        return value ? "This character has celebrity title" : "Standard character";
+                    }));
+            assertEquals("This character has celebrity title", result.get("Khal Drogo"));
+            assertEquals("Standard character", result.get("Jon Snow"));
+            assertEquals("This character has celebrity title", result.get("Ser Jorah Mormont"));
         });
     }
 

--- a/src/test/java/one/util/streamex/MoreCollectorsTest.java
+++ b/src/test/java/one/util/streamex/MoreCollectorsTest.java
@@ -668,36 +668,6 @@ public class MoreCollectorsTest {
     }
 
     /**
-     * See {@link MoreCollectors#entriesToMap(Function, BinaryOperator)}.
-     */
-    @Test
-    public void testEntriesToMapWithValueMapperAndCombiner() {
-        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToMap(null, null));
-        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToMap(null, (a, b) -> a));
-        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToMap(a -> a, null));
-
-        checkCollectorEmpty("entriesToMap", Collections.emptyMap(), MoreCollectors.entriesToMap(a -> a, (a, b) -> a));
-        {
-            Map<CharSequence, CharSequence> expected = Collections.<String, String>emptyMap().entrySet().stream()
-                    .collect(MoreCollectors.entriesToMap(a -> a, (a, b) -> a));
-            assertTrue(expected.isEmpty());
-        }
-
-        streamEx(() -> Stream.of(
-                EntryStream.of(1, "one", 2, "two", 3, "three", 4, "four"),
-                EntryStream.of(1, "ein", 2, "zwei", 3, "drei"),
-                EntryStream.of(1, "une", 2, "deux"))
-                .flatMap(Function.identity()), supplier -> {
-            Map<Integer, CharSequence> result = supplier.get().collect(
-                    MoreCollectors.entriesToMap((value) -> "['" + value + "']", (left, right) -> left + ", " + right));
-            assertEquals("['one'], ['ein'], ['une']", result.get(1));
-            assertEquals("['two'], ['zwei'], ['deux']", result.get(2));
-            assertEquals("['three'], ['drei']", result.get(3));
-            assertEquals("['four']", result.get(4));
-        });
-    }
-
-    /**
      * See {@link MoreCollectors#entriesToCustomMap(Supplier)}.
      */
     @Test
@@ -805,40 +775,6 @@ public class MoreCollectorsTest {
                 NavigableMap<Integer, CharSequence> result = supplier.get().collect(
                         MoreCollectors.entriesToCustomMap((left, right) -> left + " -> " + right, TreeMap::new));
                 assertEquals("2=* -> * -> * -> *", result.entrySet().iterator().next().toString());
-        });
-    }
-
-    /**
-     * See {@link MoreCollectors#entriesToCustomMap(Function, BinaryOperator, Supplier)}.
-     */
-    @Test
-    public void testEntriesToCustomMapWithValueMapperAndCombiner() {
-        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToCustomMap(null, null, null));
-        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToCustomMap(null, null, TreeMap::new));
-        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToCustomMap(null, (a, b) -> a, null));
-        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToCustomMap(a -> a, null, null));
-        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToCustomMap(a -> a, null, TreeMap::new));
-        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToCustomMap(a -> a, (a, b) -> a, null));
-
-        checkCollectorEmpty("entriesToCustomMap", Collections.emptyMap(),
-                MoreCollectors.entriesToCustomMap(a -> a, (a, b) -> a, TreeMap::new));
-
-        streamEx(() -> Stream.of(
-                EntryStream.of(100, "hundred", 2, "two", 3, "three", 4, "four"),
-                EntryStream.of(100, "hundert", 2, "zwei", 3, "drei"),
-                EntryStream.of(100, "cent", 2, "deux"))
-                .flatMap(Function.identity()), supplier -> {
-            NavigableMap<Integer, CharSequence> result = supplier.get().collect(
-                    MoreCollectors.entriesToCustomMap((value) -> "['" + value + "']", (left, right) -> left + ", " + right, TreeMap::new));
-            assertEquals("['hundred'], ['hundert'], ['cent']", result.get(100));
-            assertEquals("['two'], ['zwei'], ['deux']", result.get(2));
-            assertEquals("['three'], ['drei']", result.get(3));
-            assertEquals("['four']", result.get(4));
-
-            assertEquals(2, (int) result.firstKey());
-            assertEquals("['two'], ['zwei'], ['deux']", result.firstEntry().getValue());
-            assertEquals(100, (int) result.lastKey());
-            assertEquals("['hundred'], ['hundert'], ['cent']", result.lastEntry().getValue());
         });
     }
 

--- a/src/test/java/one/util/streamex/MoreCollectorsTest.java
+++ b/src/test/java/one/util/streamex/MoreCollectorsTest.java
@@ -626,12 +626,12 @@ public class MoreCollectorsTest {
     @Test
     public void testEntriesToMapWithCombiner() {
         streamEx(() -> Stream.of(
-                EntryStream.of(1, "*").toMap(),
-                EntryStream.of(1, "*", 2, "*").toMap(),
-                EntryStream.of(1, "*", 2, "*", 3, "*").toMap(),
-                EntryStream.of(1, "*", 2, "*", 3, "*", 4, "*").toMap(),
-                EntryStream.of(1, "*", 2, "*", 3, "*", 4, "*", 5, "*").toMap())
-                .flatMap(map -> map.entrySet().stream()), supplier -> {
+                EntryStream.of(1, "*"),
+                EntryStream.of(1, "*", 2, "*"),
+                EntryStream.of(1, "*", 2, "*", 3, "*"),
+                EntryStream.of(1, "*", 2, "*", 3, "*", 4, "*"),
+                EntryStream.of(1, "*", 2, "*", 3, "*", 4, "*", 5, "*"))
+                .flatMap(Function.identity()), supplier -> {
             Map<Integer, String> result = supplier.get().collect(MoreCollectors.entriesToMap(String::concat));
             assertEquals("*****", result.get(1));
             assertEquals("****", result.get(2));
@@ -641,10 +641,10 @@ public class MoreCollectorsTest {
         });
 
         streamEx(() -> Stream.of(
-                EntryStream.of(1, "one", 2, "two", 3, "three", 4, "four").toMap(),
-                EntryStream.of(1, "ein", 2, "zwei", 3, "drei").toMap(),
-                EntryStream.of(1, "une", 2, "deux").toMap())
-                .flatMap(map -> map.entrySet().stream()), supplier -> {
+                EntryStream.of(1, "one", 2, "two", 3, "three", 4, "four"),
+                EntryStream.of(1, "ein", 2, "zwei", 3, "drei"),
+                EntryStream.of(1, "une", 2, "deux"))
+                .flatMap(Function.identity()), supplier -> {
             Map<Integer, String> result = supplier.get().collect(MoreCollectors.entriesToMap((left, right) -> left + "," + right));
             assertEquals("one,ein,une", result.get(1));
             assertEquals("two,zwei,deux", result.get(2));
@@ -658,6 +658,8 @@ public class MoreCollectorsTest {
      */
     @Test
     public void testEntriesToMapWithValueMapper() {
+        Function<String, String> nullFunction = null;
+        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToMap(nullFunction));
         streamEx(() -> EntryStream.of(1, "one", 2, "two", 3, "three", 4, "four"),
                 supplier -> {
             Map<Integer, String> result = supplier.get().collect(MoreCollectors.entriesToMap((value) -> "See #" + value));
@@ -684,12 +686,13 @@ public class MoreCollectorsTest {
     @Test
     public void testEntriesToMapWithValueMapperAndCombiner() {
         assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToMap(null, null));
+        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToMap(null, (a, b) -> a));
 
         streamEx(() -> Stream.of(
-                EntryStream.of(1, "one", 2, "two", 3, "three", 4, "four").toMap(),
-                EntryStream.of(1, "ein", 2, "zwei", 3, "drei").toMap(),
-                EntryStream.of(1, "une", 2, "deux").toMap())
-                .flatMap(map -> map.entrySet().stream()), supplier -> {
+                EntryStream.of(1, "one", 2, "two", 3, "three", 4, "four"),
+                EntryStream.of(1, "ein", 2, "zwei", 3, "drei"),
+                EntryStream.of(1, "une", 2, "deux"))
+                .flatMap(Function.identity()), supplier -> {
             Map<Integer, String> result = supplier.get().collect(
                     MoreCollectors.entriesToMap((value) -> "['" + value + "']", (left, right) -> left + ", " + right));
             assertEquals("['one'], ['ein'], ['une']", result.get(1));
@@ -750,6 +753,9 @@ public class MoreCollectorsTest {
      */
     @Test
     public void testEntriesToCustomMapWithValueMapper() {
+        Function<String, String> nullFunction = null;
+        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToCustomMap(nullFunction, LinkedHashMap::new));
+
         assertThrows(IllegalStateException.class, () ->
                 EntryStream.generate(() -> "a", () -> 1).limit(10).collect(
                         MoreCollectors.entriesToCustomMap((value) -> "['" + value + "']", LinkedHashMap::new)));
@@ -774,10 +780,10 @@ public class MoreCollectorsTest {
     @Test
     public void testEntriesToCustomMapWithCombiner() {
         streamEx(() -> Stream.of(
-                EntryStream.of(100, "hundred", 2, "two", 3, "three", 4, "four").toMap(),
-                EntryStream.of(100, "hundert", 2, "zwei", 3, "drei").toMap(),
-                EntryStream.of(100, "cent", 2, "deux").toMap())
-                .flatMap(map -> map.entrySet().stream()), supplier -> {
+                EntryStream.of(100, "hundred", 2, "two", 3, "three", 4, "four"),
+                EntryStream.of(100, "hundert", 2, "zwei", 3, "drei"),
+                EntryStream.of(100, "cent", 2, "deux"))
+                .flatMap(Function.identity()), supplier -> {
             NavigableMap<Integer, String> result = supplier.get().collect(
                     MoreCollectors.entriesToCustomMap((left, right) -> left + " -> " + right, TreeMap::new));
             assertEquals("hundred -> hundert -> cent", result.get(100));
@@ -792,12 +798,12 @@ public class MoreCollectorsTest {
         });
 
         streamEx(() -> Stream.of(
-                EntryStream.of(10, "*").toMap(),
-                EntryStream.of(10, "*", 2, "*").toMap(),
-                EntryStream.of(10, "*", 2, "*", 100, "*").toMap(),
-                EntryStream.of(10, "*", 2, "*", 100, "*", 4, "*").toMap(),
-                EntryStream.of(10, "*", 2, "*", 100, "*", 4, "*", 5, "*").toMap())
-                .flatMap(map -> map.entrySet().stream()), supplier -> {
+                EntryStream.of(10, "*"),
+                EntryStream.of(10, "*", 2, "*"),
+                EntryStream.of(10, "*", 2, "*", 100, "*"),
+                EntryStream.of(10, "*", 2, "*", 100, "*", 4, "*"),
+                EntryStream.of(10, "*", 2, "*", 100, "*", 4, "*", 5, "*"))
+                .flatMap(Function.identity()), supplier -> {
 
                 NavigableMap<Integer, String> result = supplier.get().collect(
                         MoreCollectors.entriesToCustomMap((left, right) -> left + " -> " + right, TreeMap::new));
@@ -811,12 +817,15 @@ public class MoreCollectorsTest {
     @Test
     public void testEntriesToCustomMapWithValueMapperAndCombiner() {
         assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToCustomMap(null, null, null));
+        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToCustomMap(null, (a, b) -> a, null));
+        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToCustomMap(null, null, TreeMap::new));
+        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToCustomMap(null, (a, b) -> a, TreeMap::new));
 
         streamEx(() -> Stream.of(
-                EntryStream.of(100, "hundred", 2, "two", 3, "three", 4, "four").toMap(),
-                EntryStream.of(100, "hundert", 2, "zwei", 3, "drei").toMap(),
-                EntryStream.of(100, "cent", 2, "deux").toMap())
-                .flatMap(map -> map.entrySet().stream()), supplier -> {
+                EntryStream.of(100, "hundred", 2, "two", 3, "three", 4, "four"),
+                EntryStream.of(100, "hundert", 2, "zwei", 3, "drei"),
+                EntryStream.of(100, "cent", 2, "deux"))
+                .flatMap(Function.identity()), supplier -> {
             NavigableMap<Integer, String> result = supplier.get().collect(
                     MoreCollectors.entriesToCustomMap((value) -> "['" + value + "']", (left, right) -> left + ", " + right, TreeMap::new));
             assertEquals("['hundred'], ['hundert'], ['cent']", result.get(100));

--- a/src/test/java/one/util/streamex/MoreCollectorsTest.java
+++ b/src/test/java/one/util/streamex/MoreCollectorsTest.java
@@ -614,13 +614,12 @@ public class MoreCollectorsTest {
             Supplier<Stream<Entry<Integer, String>>> stream = expected.entrySet()::stream;
             checkCollector("entriesToMap", expected, stream, MoreCollectors.entriesToMap());
 
-            streamEx(stream, supplier -> {
-                Map<Integer, CharSequence> result = supplier.get().collect(MoreCollectors.entriesToMap());
-                assertEquals("*", result.get(1));
-                assertEquals("**", result.get(2));
-                assertEquals("***", result.get(3));
-                assertEquals("****", result.get(4));
-                assertEquals("*****", result.get(5));
+            streamEx(() -> EntryStream.of("one", "*", "two", "**", "three", "***", "four", "****").stream(), supplier -> {
+                Map<CharSequence, CharSequence> result = supplier.get().collect(MoreCollectors.entriesToMap());
+                assertEquals("*", result.get("one"));
+                assertEquals("**", result.get("two"));
+                assertEquals("***", result.get("three"));
+                assertEquals("****", result.get("four"));
             });
         }
     }

--- a/src/test/java/one/util/streamex/MoreCollectorsTest.java
+++ b/src/test/java/one/util/streamex/MoreCollectorsTest.java
@@ -630,8 +630,7 @@ public class MoreCollectorsTest {
      */
     @Test
     public void testEntriesToMapWithCombiner() {
-        BinaryOperator<String> nullCombiner = null;
-        assertThrows(NullPointerException.class, () -> EntryStream.of(1, "*").stream().collect(MoreCollectors.entriesToMap(nullCombiner)));
+        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToMap(null));
 
         checkCollectorEmpty("entriesToMap", Collections.emptyMap(), MoreCollectors.entriesToMap(String::concat));
         {
@@ -675,9 +674,14 @@ public class MoreCollectorsTest {
     public void testEntriesToMapWithValueMapperAndCombiner() {
         assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToMap(null, null));
         assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToMap(null, (a, b) -> a));
-        BinaryOperator<String> nullCombiner = null;
-        assertThrows(NullPointerException.class, () -> EntryStream.of(1, "*").stream().collect(
-                MoreCollectors.entriesToMap(Function.identity(), nullCombiner)));
+        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToMap(a -> a, null));
+
+        checkCollectorEmpty("entriesToMap", Collections.emptyMap(), MoreCollectors.entriesToMap(a -> a, (a, b) -> a));
+        {
+            Map<CharSequence, CharSequence> expected = Collections.<String, String>emptyMap().entrySet().stream()
+                    .collect(MoreCollectors.entriesToMap(a -> a, (a, b) -> a));
+            assertTrue(expected.isEmpty());
+        }
 
         streamEx(() -> Stream.of(
                 EntryStream.of(1, "one", 2, "two", 3, "three", 4, "four"),
@@ -698,14 +702,15 @@ public class MoreCollectorsTest {
      */
     @Test
     public void testEntriesToCustomMap() {
-        assertThrows(NullPointerException.class, () ->
-                EntryStream.of("a", "*", "b", null).collect(MoreCollectors.entriesToCustomMap(LinkedHashMap::new)));
+        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToCustomMap(null));
+        assertThrows(NullPointerException.class, () -> EntryStream.of("a", "*", "b", null).collect(
+                MoreCollectors.entriesToCustomMap(LinkedHashMap::new)));
 
-        assertThrows(IllegalStateException.class, () ->
-                EntryStream.generate(() -> "a", () -> 1).limit(10).collect(MoreCollectors.entriesToCustomMap(LinkedHashMap::new)));
-        streamEx(() -> EntryStream.of("a", "*", "a", "**").stream(), supplier -> {
-            checkIllegalStateException(() -> supplier.get().collect(MoreCollectors.entriesToCustomMap(TreeMap::new)), "a", "*", "**");
-        });
+        assertThrows(IllegalStateException.class, () -> EntryStream.generate(() -> "a", () -> 1).limit(10).collect(
+                MoreCollectors.entriesToCustomMap(LinkedHashMap::new)));
+        streamEx(() -> EntryStream.of("a", "*", "a", "**").stream(),
+                supplier -> checkIllegalStateException(() -> supplier.get().collect(
+                        MoreCollectors.entriesToCustomMap(TreeMap::new)), "a", "*", "**"));
 
         checkCollectorEmpty("entriesToMap", Collections.emptyMap(),
                 MoreCollectors.entriesToCustomMap(HashMap::new));
@@ -756,10 +761,12 @@ public class MoreCollectorsTest {
      */
     @Test
     public void testEntriesToCustomMapWithCombiner() {
-        BinaryOperator<String> nullCombiner = null;
-        assertThrows(NullPointerException.class, () -> EntryStream.of(1, "*").stream().collect(MoreCollectors.entriesToCustomMap(nullCombiner, TreeMap::new)));
+        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToCustomMap(null, null));
+        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToCustomMap((a, b) -> a, null));
+        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToCustomMap(null, TreeMap::new));
 
-        checkCollectorEmpty("entriesToMap", Collections.emptyMap(), MoreCollectors.entriesToCustomMap(String::concat, TreeMap::new));
+        checkCollectorEmpty("entriesToCustomMap", Collections.emptyMap(),
+                MoreCollectors.entriesToCustomMap((a, b) -> a, TreeMap::new));
         {
             Map<CharSequence, CharSequence> expected = Collections.<String, String>emptyMap().entrySet().stream()
                     .collect(MoreCollectors.entriesToCustomMap((a, b) -> b, TreeMap::new));
@@ -804,13 +811,14 @@ public class MoreCollectorsTest {
     @Test
     public void testEntriesToCustomMapWithValueMapperAndCombiner() {
         assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToCustomMap(null, null, null));
-        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToCustomMap(null, (a, b) -> a, null));
         assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToCustomMap(null, null, TreeMap::new));
-        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToCustomMap(null, (a, b) -> a, TreeMap::new));
-        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToCustomMap(null, (a, b) -> a, TreeMap::new));
-        BinaryOperator<String> nullCombiner = null;
-        assertThrows(NullPointerException.class, () -> EntryStream.of(1, "*").stream().collect(
-                MoreCollectors.entriesToCustomMap(Function.identity(), nullCombiner, TreeMap::new)));
+        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToCustomMap(null, (a, b) -> a, null));
+        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToCustomMap(a -> a, null, null));
+        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToCustomMap(a -> a, null, TreeMap::new));
+        assertThrows(NullPointerException.class, () -> MoreCollectors.entriesToCustomMap(a -> a, (a, b) -> a, null));
+
+        checkCollectorEmpty("entriesToCustomMap", Collections.emptyMap(),
+                MoreCollectors.entriesToCustomMap(a -> a, (a, b) -> a, TreeMap::new));
 
         streamEx(() -> Stream.of(
                 EntryStream.of(100, "hundred", 2, "two", 3, "three", 4, "four"),

--- a/src/test/java/one/util/streamex/TestHelpers.java
+++ b/src/test/java/one/util/streamex/TestHelpers.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntConsumer;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
@@ -445,6 +446,11 @@ public class TestHelpers {
     }
 
     static void assertThrows(Class<? extends Throwable> expected, Statement statement) {
+        assertThrows(expected, msg -> true, statement);
+    }
+
+    static void assertThrows(Class<? extends Throwable> expected, Predicate<? super String> checkExceptionAction,
+                             Statement statement) {
         try {
             statement.evaluate();
         } catch (Throwable e) {
@@ -452,6 +458,9 @@ public class TestHelpers {
                 throw new AssertionError("Unexpected exception, " +
                         "expected<" + expected.getName() + "> " +
                         "but was<" + e.getClass().getName() + ">", e);
+            }
+            if (!checkExceptionAction.test(e.getMessage())) {
+                fail("Unexpected exception<" + e.getMessage() + ">");
             }
             return;
         }

--- a/wiki/CHANGES.md
+++ b/wiki/CHANGES.md
@@ -4,6 +4,7 @@ Check also [MIGRATION.md](MIGRATION.md) for possible compatibility problems.
 
 ### 0.7.3
 * [#028]: Added: `StreamEx.toCollectionAndThen`
+* [#043]: Added: Add `MoreCollectors.entriesToMap` and `MoreCollectors.entriesToCustomMap` methods accepting Entry<K,V>. 
 * [#219]: Changed: MoreCollectors now reject eagerly null parameters where possible; `MoreCollectors.last` throws NPE if last stream element is null.
 * [#221]: Fixed: `rangeClosed(x, x, step)` returned empty stream instead of stream of `x` if step absolute value is
  bigger than one. 

--- a/wiki/CHEATSHEET.md
+++ b/wiki/CHEATSHEET.md
@@ -259,7 +259,8 @@ What I want | How to get it
 --- | ---
 Collect to array | `MoreCollectors.toArray()`
 Collect to boolean array using the `Predicate` applied to each element | `MoreCollectors.toBooleanArray()`
-Collect `Map.Entry` entries to `HashMap` | `MoreCollectors.entriesToMap()`
+Collect to `EnumSet` | `MoreCollectors.toEnumSet()`
+Collect `Map.Entry` entries to map | `MoreCollectors.entriesToMap()`
 Collect `Map.Entry` entries to custom `Map` implementation | `MoreCollectors.entriesToCustomMap()`
 Count number of distinct elements using custom key extractor | `MoreCollectors.distinctCount()`
 Get the `List` of distinct elements using custom key extractor | `MoreCollectors.distinctBy()`

--- a/wiki/CHEATSHEET.md
+++ b/wiki/CHEATSHEET.md
@@ -260,7 +260,7 @@ What I want | How to get it
 Collect to array | `MoreCollectors.toArray()`
 Collect to boolean array using the `Predicate` applied to each element | `MoreCollectors.toBooleanArray()`
 Collect `Map.Entry` entries to `HashMap` | `MoreCollectors.entriesToMap()`
-Collect `Map.Entry` entries to cstom `Map` implementation | `MoreCollectors.entriesToCustomMap()`
+Collect `Map.Entry` entries to custom `Map` implementation | `MoreCollectors.entriesToCustomMap()`
 Count number of distinct elements using custom key extractor | `MoreCollectors.distinctCount()`
 Get the `List` of distinct elements using custom key extractor | `MoreCollectors.distinctBy()`
 Simply counting, but get the result as `Integer` | `MoreCollectors.countingInt()`

--- a/wiki/CHEATSHEET.md
+++ b/wiki/CHEATSHEET.md
@@ -5,25 +5,25 @@
 * [Glossary](#glossary)
 * [Stream sources](#stream-sources)
 * [New intermediate operations](#new-intermediate-operations)
- * [filtering](#filtering)
- * [mapping](#mapping)
- * [flat-mapping](#flat-mapping)
- * [distinct](#distinct)
- * [sorting](#sorting)
- * [partial reduction](#partial-reduction)
- * [concatenate](#concatenate)
- * [peek](#peek)
- * [misc](#misc-intermediate-operations)
+  * [filtering](#filtering)
+  * [mapping](#mapping)
+  * [flat-mapping](#flat-mapping)
+  * [distinct](#distinct)
+  * [sorting](#sorting)
+  * [partial reduction](#partial-reduction)
+  * [concatenate](#concatenate)
+  * [peek](#peek)
+  * [misc](#misc-intermediate-operations)
 * [New terminal operations](#new-terminal-operations)
- * [Collector shortcuts](#collector-shortcuts)
- * [Search](#search)
- * [Folding](#folding)
- * [Primitive operations](#primitive-operations)
- * [forEach-like operations](#foreach-like-operations)
- * [misc](#misc-terminal-operations)
+  * [Collector shortcuts](#collector-shortcuts)
+  * [Search](#search)
+  * [Folding](#folding)
+  * [Primitive operations](#primitive-operations)
+  * [forEach-like operations](#foreach-like-operations)
+  * [misc](#misc-terminal-operations)
 * [Collectors](#collectors)
- * [Basic collectors](#basic-collectors)
- * [Adaptor collectors](#adaptor-collectors)
+  * [Basic collectors](#basic-collectors)
+  * [Adaptor collectors](#adaptor-collectors)
 
 ## Glossary
 
@@ -259,7 +259,8 @@ What I want | How to get it
 --- | ---
 Collect to array | `MoreCollectors.toArray()`
 Collect to boolean array using the `Predicate` applied to each element | `MoreCollectors.toBooleanArray()`
-Collect to `EnumSet` | `MoreCollectors.toEnumSet()`
+Collect `Map.Entry` entries to `HashMap` | `MoreCollectors.entriesToMap()`
+Collect `Map.Entry` entries to cstom `Map` implementation | `MoreCollectors.entriesToCustomMap()`
 Count number of distinct elements using custom key extractor | `MoreCollectors.distinctCount()`
 Get the `List` of distinct elements using custom key extractor | `MoreCollectors.distinctBy()`
 Simply counting, but get the result as `Integer` | `MoreCollectors.countingInt()`


### PR DESCRIPTION
- 8 new shortcuts in **_MoreCollectors_** were created:
   - entriesToMap with 4 signatures
   - entriesToCustomMap with 4 signatures
- all signatures are covered by tests including cases with excpetions and different maps(TreeMap, LinkedHashMap)
