### PR TITLE
Issue/#238 to map with identity

### DIFF
--- a/src/main/java/one/util/streamex/StreamEx.java
+++ b/src/main/java/one/util/streamex/StreamEx.java
@@ -966,7 +966,8 @@ public class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
     /**
      * Returns a {@link Map} whose keys are elements from this stream and values
      * are the result of applying the provided mapping functions to the input elements.
-     * It is just alias for #toMap(Function)
+     *
+     * This is just alias for #toMap(Function).
      *
      * @param <V> the output type of the value mapping function
      * @param valMapper a mapping function to produce values
@@ -975,14 +976,15 @@ public class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
      * @throws IllegalStateException if this stream contains duplicate objects
      *         (according to {@link Object#equals(Object)})
      * @see #toMap(Function)
+     * @since 0.7.4
      */
     public <V> Map<T, V> toMapWithIdentityKeyMapper(Function<? super T, ? extends V> valMapper) {
         return toMap(valMapper);
     }
 
     /**
-     * Returns a {@link Map} whose values are elements from this stream and
-     * keys are the result of applying the provided mapping functions to the input elements.
+     * Returns a {@link Map} whose keys are the result of applying the provided mapping functions to the input elements
+     * and values are elements from this stream.
      *
      * <p>
      * This is a <a href="package-summary.html#StreamOps">terminal</a> operation.
@@ -1002,6 +1004,7 @@ public class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
      * @see Collectors#toMap(Function, Function)
      * @see Collectors#toConcurrentMap(Function, Function)
      * @see #toMap(Function, Function)
+     * @since 0.7.4
      */
     public <K> Map<K, T> toMapWithIdentityValueMapper(Function<? super T, ? extends K> keyMapper) {
         return toMap(keyMapper, Function.identity());
@@ -1149,6 +1152,50 @@ public class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
     }
 
     /**
+     * Returns a {@link SortedMap} whose keys are elements from this stream and
+     * values are the result of applying the provided mapping functions to the input elements.
+     *
+     * This is simple alias for #toSortedMap(Function).
+     *
+     * @see #toSortedMap(Function, Function)
+     * @see #toSortedMap(Function)
+     * @since 0.7.4
+     */
+    public <V> SortedMap<T, V> toSortedMapWithIdentityKeyMapper(Function<? super T, ? extends V> valMapper) {
+        return toSortedMap(valMapper);
+    }
+
+    /**
+     * Returns a {@link SortedMap} whose
+     * keys are the result of applying the provided mapping function to the input elements
+     * and values are elements from this stream.
+     *
+     * <p>
+     * This is a <a href="package-summary.html#StreamOps">terminal</a> operation.
+     *
+     * <p>
+     * If this stream contains duplicates (according to
+     * {@link Object#equals(Object)}), an {@code IllegalStateException} is
+     * thrown when the collection operation is performed.
+     *
+     * <p>
+     * For parallel stream the concurrent {@code SortedMap} is created.
+     *
+     * <p>
+     * Returned {@code SortedMap} is guaranteed to be modifiable.
+     *
+     * @param <K>       the output type of the key mapping function
+     * @param keyMapper a mapping function to produce keys
+     * @return a {@code SortedMap} whose keys are the result of applying mapping function to the input elements and
+     * values are elements from this stream
+     * @see #toSortedMap(Function, Function)
+     * @since 0.7.4
+     */
+    public <K> SortedMap<K, T> toSortedMapWithIdentityValueMapper(Function<? super T, ? extends K> keyMapper) {
+        return toSortedMap(keyMapper, Function.identity());
+    }
+
+    /**
      * Returns a {@link SortedMap} whose keys and values are the result of
      * applying the provided mapping functions to the input elements.
      *
@@ -1259,7 +1306,50 @@ public class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
     public <V> NavigableMap<T, V> toNavigableMap(Function<? super T, ? extends V> valMapper) {
         return toNavigableMap(Function.identity(), valMapper);
     }
-    
+
+    /**
+     * Returns a {@link NavigableMap} whose keys are elements from this stream and
+     * values are the result of applying the provided mapping functions to the input elements.
+     * <p>
+     * This is simple alias for #toNavigableMap(Function).
+     *
+     * @see #toNavigableMap(Function, Function)
+     * @see #toNavigableMap(Function)
+     * @since 0.7.4
+     */
+    public <V> NavigableMap<T, V> toNavigableMapWithIdentityKeyMapper(Function<? super T, ? extends V> valMapper) {
+        return toNavigableMap(valMapper);
+    }
+
+    /**
+     * Returns a {@link NavigableMap} whose
+     * keys are the result of applying the provided mapping functions to the input elements
+     * and values are elements from this stream.
+     *
+     * <p>
+     * This is a <a href="package-summary.html#StreamOps">terminal</a> operation.
+     *
+     * <p>
+     * If this stream contains duplicates (according to {@link Object#equals(Object)}),
+     * an {@code IllegalStateException} is thrown when the collection operation is performed.
+     *
+     * <p>
+     * For parallel stream the concurrent {@code NavigableMap} is created.
+     *
+     * <p>
+     * Returned {@code NavigableMap} is guaranteed to be modifiable.
+     *
+     * @param <K>       the output type of the key mapping function
+     * @param keyMapper a mapping function to produce keys
+     * @return a {@code NavigableMap} whose keys are the result of applying the provided mapping functions to the
+     * input elements  and values are elements from this stream
+     * @see #toNavigableMap(Function, Function)
+     * @since 0.7.4
+     */
+    public <K> NavigableMap<K, T> toNavigableMapWithIdentityValueMapper(Function<? super T, ? extends K> keyMapper) {
+        return toNavigableMap(keyMapper, Function.identity());
+    }
+
     /**
      * Returns a {@link NavigableMap} whose keys and values are the result of
      * applying the provided mapping functions to the input elements.

--- a/src/main/java/one/util/streamex/StreamEx.java
+++ b/src/main/java/one/util/streamex/StreamEx.java
@@ -957,9 +957,54 @@ public class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
      * @see Collectors#toMap(Function, Function)
      * @see Collectors#toConcurrentMap(Function, Function)
      * @see #toMap(Function, Function)
+     * @see #toMapWithIdentityKeyMapper(Function)
      */
     public <V> Map<T, V> toMap(Function<? super T, ? extends V> valMapper) {
         return toMap(Function.identity(), valMapper);
+    }
+
+    /**
+     * Returns a {@link Map} whose keys are elements from this stream and values
+     * are the result of applying the provided mapping functions to the input elements.
+     * It is just alias for #toMap(Function)
+     *
+     * @param <V> the output type of the value mapping function
+     * @param valMapper a mapping function to produce values
+     * @return a {@code Map} whose keys are elements from this stream and values
+     *         are the result of applying mapping function to the input elements
+     * @throws IllegalStateException if this stream contains duplicate objects
+     *         (according to {@link Object#equals(Object)})
+     * @see #toMap(Function)
+     */
+    public <V> Map<T, V> toMapWithIdentityKeyMapper(Function<? super T, ? extends V> valMapper) {
+        return toMap(valMapper);
+    }
+
+    /**
+     * Returns a {@link Map} whose values are elements from this stream and
+     * keys are the result of applying the provided mapping functions to the input elements.
+     *
+     * <p>
+     * This is a <a href="package-summary.html#StreamOps">terminal</a> operation.
+     *
+     * <p>
+     * Returned {@code Map} is guaranteed to be modifiable.
+     *
+     * <p>
+     * For parallel stream the concurrent {@code Map} is created.
+     *
+     * @param <K>       the output type of the key mapping function
+     * @param keyMapper a mapping function to produce keys
+     * @return a {@code Map} whose values are elements from this stream and
+     * keys are the result of applying mapping function to the input elements
+     * @throws IllegalStateException if this stream contains duplicate objects
+     *                               (according to {@link Object#equals(Object)})
+     * @see Collectors#toMap(Function, Function)
+     * @see Collectors#toConcurrentMap(Function, Function)
+     * @see #toMap(Function, Function)
+     */
+    public <K> Map<K, T> toMapWithIdentityValueMapper(Function<? super T, ? extends K> keyMapper) {
+        return toMap(keyMapper, Function.identity());
     }
 
     /**

--- a/src/test/java/one/util/streamex/api/StreamExTest.java
+++ b/src/test/java/one/util/streamex/api/StreamExTest.java
@@ -350,6 +350,52 @@ public class StreamExTest {
     }
 
     @Test
+    public void testToMapWithIdentityKeyMapper() {
+        Map<String, Integer> expected = new HashMap<>();
+        expected.put("a", 1);
+        expected.put("bb", 2);
+        expected.put("ccc", 3);
+
+        Map<String, Character> expected2 = new HashMap<>();
+        expected2.put("a", 'a');
+        expected2.put("bb", 'b');
+        expected2.put("ccc", 'c');
+
+        streamEx(() -> Stream.of("a", "bb", "ccc"), supplier -> {
+            Map<String, Integer> map = supplier.get().toMapWithIdentityKeyMapper(String::length);
+            assertEquals(supplier.get().isParallel(), map instanceof ConcurrentMap);
+            assertEquals(expected, map);
+
+            Map<String, Character> map2 = supplier.get().toMapWithIdentityKeyMapper(s -> s.charAt(0));
+            assertEquals(supplier.get().isParallel(), map2 instanceof ConcurrentMap);
+            assertEquals(expected2, map2);
+        });
+   }
+
+    @Test
+    public void testToMapWithIdentityValueMapper() {
+        Map<Integer, String> expected = new HashMap<>();
+        expected.put(1, "a");
+        expected.put(2, "bb");
+        expected.put(3, "ccc");
+
+        Map<Character, String> expected2 = new HashMap<>();
+        expected2.put('a', "a");
+        expected2.put('b', "bb");
+        expected2.put('c', "ccc");
+
+        streamEx(() -> Stream.of("a", "bb", "ccc"), supplier -> {
+            Map<Integer, String> map = supplier.get().toMapWithIdentityValueMapper(String::length);
+            assertEquals(supplier.get().isParallel(), map instanceof ConcurrentMap);
+            assertEquals(expected, map);
+
+            Map<Character, String> map2 = supplier.get().toMapWithIdentityValueMapper(s -> s.charAt(0));
+            assertEquals(supplier.get().isParallel(), map2 instanceof ConcurrentMap);
+            assertEquals(expected2, map2);
+        });
+    }
+
+    @Test
     public void testToSortedMap() {
         Map<String, Integer> expected = new HashMap<>();
         expected.put("a", 1);

--- a/src/test/java/one/util/streamex/api/StreamExTest.java
+++ b/src/test/java/one/util/streamex/api/StreamExTest.java
@@ -432,6 +432,52 @@ public class StreamExTest {
     }
 
     @Test
+    public void testToSortedMapWithIdentityKeyMapper() {
+        Map<String, Integer> expected = new HashMap<>();
+        expected.put("a", 1);
+        expected.put("bb", 2);
+        expected.put("ccc", 3);
+
+        Map<String, Character> expected2 = new HashMap<>();
+        expected2.put("a", 'a');
+        expected2.put("bb", 'b');
+        expected2.put("ccc", 'c');
+
+        streamEx(() -> Stream.of("a", "bb", "ccc"), supplier -> {
+            SortedMap<String, Integer> map = supplier.get().toSortedMapWithIdentityKeyMapper(String::length);
+            assertEquals(supplier.get().isParallel(), map instanceof ConcurrentMap);
+            assertEquals(expected, map);
+
+            SortedMap<String, Character> map2 = supplier.get().toSortedMapWithIdentityKeyMapper(s -> s.charAt(0));
+            assertEquals(supplier.get().isParallel(), map2 instanceof ConcurrentMap);
+            assertEquals(expected2, map2);
+        });
+    }
+
+    @Test
+    public void testToSortedMapWithIdentityValueMapper() {
+        Map<Integer, String> expected = new HashMap<>();
+        expected.put(1, "a");
+        expected.put(2, "bb");
+        expected.put(3, "ccc");
+
+        Map<Character, String> expected2 = new HashMap<>();
+        expected2.put('a', "a");
+        expected2.put('b', "bb");
+        expected2.put('c', "ccc");
+
+        streamEx(() -> Stream.of("a", "bb", "ccc"), supplier -> {
+            SortedMap<Integer, String> map = supplier.get().toSortedMapWithIdentityValueMapper(String::length);
+            assertEquals(supplier.get().isParallel(), map instanceof ConcurrentMap);
+            assertEquals(expected, map);
+
+            SortedMap<Character, String> map2 = supplier.get().toSortedMapWithIdentityValueMapper(s -> s.charAt(0));
+            assertEquals(supplier.get().isParallel(), map2 instanceof ConcurrentMap);
+            assertEquals(expected2, map2);
+        });
+    }
+
+    @Test
     public void testToNavigableMap() {
         Map<String, Integer> expected = new HashMap<>();
         expected.put("a", 1);
@@ -464,6 +510,52 @@ public class StreamExTest {
 
             checkIllegalStateException(() -> supplier.get().toNavigableMap(String::length, Function.identity()), "2",
                 "dd", "bb");
+        });
+    }
+
+    @Test
+    public void testToNavigableMapWithIdentityKeyMapper() {
+        Map<String, Integer> expected = new HashMap<>();
+        expected.put("a", 1);
+        expected.put("bb", 2);
+        expected.put("ccc", 3);
+
+        Map<String, Character> expected2 = new HashMap<>();
+        expected2.put("a", 'a');
+        expected2.put("bb", 'b');
+        expected2.put("ccc", 'c');
+
+        streamEx(() -> Stream.of("a", "bb", "ccc"), supplier -> {
+            NavigableMap<String, Integer> map = supplier.get().toNavigableMapWithIdentityKeyMapper(String::length);
+            assertEquals(supplier.get().isParallel(), map instanceof ConcurrentMap);
+            assertEquals(expected, map);
+
+            NavigableMap<String, Character> map2 = supplier.get().toNavigableMapWithIdentityKeyMapper(s -> s.charAt(0));
+            assertEquals(supplier.get().isParallel(), map2 instanceof ConcurrentMap);
+            assertEquals(expected2, map2);
+        });
+    }
+
+    @Test
+    public void testToNavigableMapWithIdentityValueMapper() {
+        Map<Integer, String> expected = new HashMap<>();
+        expected.put(1, "a");
+        expected.put(2, "bb");
+        expected.put(3, "ccc");
+
+        Map<Character, String> expected2 = new HashMap<>();
+        expected2.put('a', "a");
+        expected2.put('b', "bb");
+        expected2.put('c', "ccc");
+
+        streamEx(() -> Stream.of("a", "bb", "ccc"), supplier -> {
+            NavigableMap<Integer, String> map = supplier.get().toNavigableMapWithIdentityValueMapper(String::length);
+            assertEquals(supplier.get().isParallel(), map instanceof ConcurrentMap);
+            assertEquals(expected, map);
+
+            NavigableMap<Character, String> map2 = supplier.get().toNavigableMapWithIdentityValueMapper(s -> s.charAt(0));
+            assertEquals(supplier.get().isParallel(), map2 instanceof ConcurrentMap);
+            assertEquals(expected2, map2);
         });
     }
 


### PR DESCRIPTION
Hi, Tagir!

According to issue #238, the idea was to simplify the usage **toMap** and introduce convenient aliases.

Please have a look at the convinient aliases:

- **toMapWithIdentityKeyMapper**= "alias for toMap(Function)" and **toMapWithIdentityValueMapper**
- **toSortedMapWithIdentityKeyMapper**= "alias for  toSortedMap(Function)" and **toSortedMapWithIdentityValueMapper**
- **toNavigableMapWithIdentityKeyMapper**= "alias for toNavigableMap(Function)"  and **toNavigableMapWithIdentityValueMapper**

Looking forward for your feedback