### PR TITLE
Include version information in module descriptor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,8 @@
         <configuration>
           <compilerArgs>
             <arg>-Xlint:all</arg>
+            <arg>--module-version</arg>
+            <arg>${project.version}</arg>
           </compilerArgs>
           <archive>
             <manifestEntries>


### PR DESCRIPTION
Although a local test via `mvn verify` failed with...

```text
[ERROR] Failed to execute goal pw.krejci:multi-release-jar-maven-plugin:0.1.5:compile (default-compile) on project streamex: Failed to prepare multi-release sources for staged compilation.: Destination '/workspaces/streamex/target/sources-9/descriptor/module-info.java' already exists -> [Help 1]
```

...this should do the trick. If not, either @metlos might help here with pointing to the right location to configure the extended maven-compiler-plugin ... or adding an additional invocation of Java's `jar --update --file ... --module-version` is the way.