### PR TITLE
Correcting a comment in EntryStream.java

### DIFF
--- a/src/main/java/one/util/streamex/EntryStream.java
+++ b/src/main/java/one/util/streamex/EntryStream.java
@@ -2156,7 +2156,7 @@ public final class EntryStream<K, V> extends AbstractStreamEx<Entry<K, V>, Entry
      * {@code Map.Entry(list.get(0), list.get(1))},
      * {@code Map.Entry(list.get(0), list.get(2))} and
      * {@code Map.Entry(list.get(1), list.get(2))}. The number of elements in
-     * the resulting stream is {@code list.size()*(list.size()+1L)/2}.
+     * the resulting stream is {@code list.size() * (list.size() - 1L) / 2}.
      *
      * <p>
      * The list values are accessed using {@link List#get(int)}, so the list
@@ -2185,7 +2185,7 @@ public final class EntryStream<K, V> extends AbstractStreamEx<Entry<K, V>, Entry
      * {@code Map.Entry(array[0], array[1])},
      * {@code Map.Entry(array[0], array[2])} and
      * {@code Map.Entry(array[1], array[2])}. The number of elements in the
-     * resulting stream is {@code array.length*(array.length+1L)/2}..
+     * resulting stream is {@code array.length * (array.length - 1L) / 2}..
      *
      * @param <T> type of the array elements
      * @param array a array to take the elements from


### PR DESCRIPTION
in EntryStream.java, in the ofPairs() methods, there was an error in the formula for the size of the output EntryStream.

The ofPairs() methods by its nature calculate all possible combinations of list items (*Actually, I don't really understand why it's not called ofCombinations()*).

The formula for combinations is as follows:
![image](https://github.com/amaembo/streamex/assets/81202331/27990149-c075-4d83-93e3-4fe1702749a2)

If we take our specific case, where r = 2, the formula will look like this:
![image](https://github.com/amaembo/streamex/assets/81202331/f3dcae0b-4f52-4164-b2e8-8eae29db59f0)




