### PR TITLE
handle throwable functions in methods of StreamEx

### DIFF
--- a/src/main/java/one/util/functionex/ThrowableBinaryOperator.java
+++ b/src/main/java/one/util/functionex/ThrowableBinaryOperator.java
@@ -1,0 +1,37 @@
+package one.util.functionex;
+
+import java.util.Comparator;
+import java.util.Objects;
+
+@FunctionalInterface
+public interface ThrowableBinaryOperator<X extends Throwable, T> extends ThrowableFunction2_1<X, T, T, T>{
+    /**
+     * Returns a {@link java.util.function.BinaryOperator} which returns the lesser of two elements
+     * according to the specified {@code Comparator}.
+     *
+     * @param <T> the type of the input arguments of the comparator
+     * @param comparator a {@code Comparator} for comparing the two values
+     * @return a {@code BinaryOperator} which returns the lesser of its operands,
+     *         according to the supplied {@code Comparator}
+     * @throws NullPointerException if the argument is null
+     */
+    static <T> java.util.function.BinaryOperator<T> minBy(Comparator<? super T> comparator) {
+        Objects.requireNonNull(comparator);
+        return (a, b) -> comparator.compare(a, b) <= 0 ? a : b;
+    }
+
+    /**
+     * Returns a {@link java.util.function.BinaryOperator} which returns the greater of two elements
+     * according to the specified {@code Comparator}.
+     *
+     * @param <T> the type of the input arguments of the comparator
+     * @param comparator a {@code Comparator} for comparing the two values
+     * @return a {@code BinaryOperator} which returns the greater of its operands,
+     *         according to the supplied {@code Comparator}
+     * @throws NullPointerException if the argument is null
+     */
+    static <T> java.util.function.BinaryOperator<T> maxBy(Comparator<? super T> comparator) {
+        Objects.requireNonNull(comparator);
+        return (a, b) -> comparator.compare(a, b) >= 0 ? a : b;
+    }
+}

--- a/src/main/java/one/util/functionex/ThrowableBinaryOperator.java
+++ b/src/main/java/one/util/functionex/ThrowableBinaryOperator.java
@@ -2,7 +2,22 @@ package one.util.functionex;
 
 import java.util.Comparator;
 import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.UnaryOperator;
 
+/**
+ * Represents an operation upon two operands of the same type, producing a result
+ * of the same type as the operands.  This is a specialization of
+ * {@link ThrowableFunction2_1} for the case where the operands and the result are all
+ * the same type.
+ *
+ * <p>This is a <a href="package-summary.html">functional interface</a>
+ * whose functional method is {@link #apply(Object, Object)}.
+ *
+ * @param <T> the type of the operands and result of the operator
+ *
+ * @see ThrowableFunction2_1
+ */
 @FunctionalInterface
 public interface ThrowableBinaryOperator<X extends Throwable, T> extends ThrowableFunction2_1<X, T, T, T>{
     /**

--- a/src/main/java/one/util/functionex/ThrowableFunction0_0.java
+++ b/src/main/java/one/util/functionex/ThrowableFunction0_0.java
@@ -1,0 +1,153 @@
+package one.util.functionex;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents a function with no arguments and no returning values.
+ *
+ * @param <X> the exception which may throw
+ */
+@FunctionalInterface
+public interface ThrowableFunction0_0<X extends Throwable> extends Serializable {
+
+    /**
+     * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.
+     */
+    long serialVersionUID = 1L;
+
+    /**
+     * Applies this function.
+     */
+    void apply() throws X;
+
+    /**
+     * Narrows the given {@code one.util.functionex.ThrowableFunction0_0<? extends Throwable>} to {@code one.util.functionex.ThrowableFunction0_0<? extends Throwable>}
+     *
+     * @param f A {@code one.util.functionex.ThrowableFunction0_0}
+     * @return the given {@code f} instance as narrowed type {@code one.util.functionex.ThrowableFunction0_0<? extends Throwable>}
+     */
+    static ThrowableFunction0_0<? extends Throwable> narrow(ThrowableFunction0_0<? extends Throwable> f) {
+        return f;
+    }
+
+    /**
+     * Returns a composed function that first runs this function, and then runs
+     * the {@code after} runnable.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param after the runnable to apply after this
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    default ThrowableFunction0_0<X> andRun(ThrowableFunction0_0<X> after) {
+        Objects.requireNonNull(after);
+        return () -> {
+            apply();
+            after.apply();
+        };
+    }
+    /**
+     * Returns a composed function that returns a supplied value by first applying this
+     * runnable, and then applies the {@code after} function.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param after the function to apply after this function returning
+     *              a new value of type {@code V}
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @param <V> Type of parameter of the final result value supplied
+     * @throws NullPointerException if after is null
+     */
+    default <V> ThrowableFunction0_1<X, V> andSupply(ThrowableFunction0_1<X, ? extends V> after) {
+        Objects.requireNonNull(after);
+        return () -> {
+            apply();
+            return after.apply();
+        };
+    }
+    /**
+     * Returns a composed function that returns a supplied entry by first applying this
+     * function, and then applies the {@code after} function.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param after the function to apply after this function
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @param <R1> Type of key of the returned entry
+     * @param <R2> Type of value of the returned entry
+     * @throws NullPointerException if after is null
+     */
+    @SuppressWarnings("unchecked")
+    default <R1, R2> ThrowableFunction0_2<X, R1, R2> andSupplyEntry(ThrowableFunction0_2<X, ? extends R1, ? extends R2> after) {
+        Objects.requireNonNull(after);
+        return () -> {
+            apply();
+            return (Map.Entry<R1, R2>) after.apply();
+        };
+    }
+
+    /**
+     * Returns a composed function that first applies the {@code before} function,
+     * and then applies this function.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param before the function to apply before this function
+     * @return a composed function that first applies the {@code before} function and
+     * then applies this function
+     * @throws NullPointerException if before is null
+     */
+    default ThrowableFunction0_0<X> compose(ThrowableFunction0_0<X> before) {
+        Objects.requireNonNull(before);
+        return () -> {
+            before.apply();
+            apply();
+        };
+    }
+    /**
+     * Returns a composed function that first applies the {@code before} function with
+     * one parameter, and then applies this function.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param before the function to apply before this function is applied
+     * @return a composed function that first applies the {@code before} function and
+     * then applies this function
+     * @param <E> Type of parameter that take the before function
+     * @throws NullPointerException if before is null
+     */
+    default <E> ThrowableFunction1_0<X, E> compose(ThrowableFunction1_0<X, ? super E> before) {
+        Objects.requireNonNull(before);
+        return (e1) -> {
+            before.apply(e1);
+            apply();
+        };
+    }
+    /**
+     * Returns a composed function that first applies the {@code before} function with two
+     * parameters, and then applies this function.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param before the function to apply before this function
+     * @return a composed function that first applies the {@code before} function and
+     * then applies this function
+     * @param <E1> Type of first parameter that take the before function
+     * @param <E2> Type of second parameter that take the before function
+     * @throws NullPointerException if before is null
+     */
+    default <E1, E2> ThrowableFunction2_0<X, E1, E2> compose(ThrowableFunction2_0<X, ? super E1, ? super E2> before) {
+        Objects.requireNonNull(before);
+        return (e1, e2) -> {
+            before.apply(e1, e2);
+            apply();
+        };
+    }
+
+}

--- a/src/main/java/one/util/functionex/ThrowableFunction0_0.java
+++ b/src/main/java/one/util/functionex/ThrowableFunction0_0.java
@@ -1,7 +1,6 @@
 package one.util.functionex;
 
 import java.io.Serializable;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -19,6 +18,7 @@ public interface ThrowableFunction0_0<X extends Throwable> extends Serializable 
 
     /**
      * Applies this function.
+     * @throws X Exception that function may throw
      */
     void apply() throws X;
 
@@ -26,9 +26,10 @@ public interface ThrowableFunction0_0<X extends Throwable> extends Serializable 
      * Narrows the given {@code one.util.functionex.ThrowableFunction0_0<? extends Throwable>} to {@code one.util.functionex.ThrowableFunction0_0<? extends Throwable>}
      *
      * @param f A {@code one.util.functionex.ThrowableFunction0_0}
+     * @param <X>  Exception that f may declare to throw
      * @return the given {@code f} instance as narrowed type {@code one.util.functionex.ThrowableFunction0_0<? extends Throwable>}
      */
-    static ThrowableFunction0_0<? extends Throwable> narrow(ThrowableFunction0_0<? extends Throwable> f) {
+    static <X extends Throwable> ThrowableFunction0_0<X> narrow(ThrowableFunction0_0<X> f) {
         return f;
     }
 
@@ -79,16 +80,16 @@ public interface ThrowableFunction0_0<X extends Throwable> extends Serializable 
      * @param after the function to apply after this function
      * @return a composed function that first applies this function and then
      * applies the {@code after} function
-     * @param <R1> Type of key of the returned entry
-     * @param <R2> Type of value of the returned entry
+     * @param <V1> Type of key of the returned entry
+     * @param <V2> Type of value of the returned entry
      * @throws NullPointerException if after is null
      */
     @SuppressWarnings("unchecked")
-    default <R1, R2> ThrowableFunction0_2<X, R1, R2> andSupplyEntry(ThrowableFunction0_2<X, ? extends R1, ? extends R2> after) {
+    default <V1, V2> ThrowableFunction0_2<X, V1, V2> andSupplyEntry(ThrowableFunction0_2<X, ? extends V1, ? extends V2> after) {
         Objects.requireNonNull(after);
         return () -> {
             apply();
-            return (Map.Entry<R1, R2>) after.apply();
+            return (Tuple<V1, V2>) after.apply();
         };
     }
 
@@ -119,13 +120,13 @@ public interface ThrowableFunction0_0<X extends Throwable> extends Serializable 
      * @param before the function to apply before this function is applied
      * @return a composed function that first applies the {@code before} function and
      * then applies this function
-     * @param <E> Type of parameter that take the before function
+     * @param <I> Type of parameter that take the before function
      * @throws NullPointerException if before is null
      */
-    default <E> ThrowableFunction1_0<X, E> compose(ThrowableFunction1_0<X, ? super E> before) {
+    default <I> ThrowableFunction1_0<X, I> compose(ThrowableFunction1_0<X, ? super I> before) {
         Objects.requireNonNull(before);
-        return (e1) -> {
-            before.apply(e1);
+        return (i1) -> {
+            before.apply(i1);
             apply();
         };
     }
@@ -138,14 +139,14 @@ public interface ThrowableFunction0_0<X extends Throwable> extends Serializable 
      * @param before the function to apply before this function
      * @return a composed function that first applies the {@code before} function and
      * then applies this function
-     * @param <E1> Type of first parameter that take the before function
-     * @param <E2> Type of second parameter that take the before function
+     * @param <I1> Type of first parameter that take the before function
+     * @param <I2> Type of second parameter that take the before function
      * @throws NullPointerException if before is null
      */
-    default <E1, E2> ThrowableFunction2_0<X, E1, E2> compose(ThrowableFunction2_0<X, ? super E1, ? super E2> before) {
+    default <I1, I2> ThrowableFunction2_0<X, I1, I2> compose(ThrowableFunction2_0<X, ? super I1, ? super I2> before) {
         Objects.requireNonNull(before);
-        return (e1, e2) -> {
-            before.apply(e1, e2);
+        return (i1, i2) -> {
+            before.apply(i1, i2);
             apply();
         };
     }

--- a/src/main/java/one/util/functionex/ThrowableFunction0_1.java
+++ b/src/main/java/one/util/functionex/ThrowableFunction0_1.java
@@ -1,0 +1,147 @@
+package one.util.functionex;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents a function with no arguments and returning one value.
+ *
+ * @param <X> the exception which may throw
+ * @param <R> return type 1 of the function
+ */
+@FunctionalInterface
+public interface ThrowableFunction0_1<X extends Throwable, R> extends Serializable {
+
+    /**
+     * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.
+     */
+    long serialVersionUID = 1L;
+
+    /**
+     * Gets a result.
+     *
+     * @return a result
+     */
+    R apply() throws X;
+
+    /**
+     * Narrows the given {@code one.util.functionex.ThrowableFunction0_1<? extends Throwable, ? extends R>} to
+     * {@code one.util.functionex.ThrowableFunction0_1<? extends Throwable,R>}
+     *
+     * @param f A {@code one.util.functionex.ThrowableFunction0_1}
+     * @param <R> The return type
+     * @return the given {@code f} instance as narrowed type {@code one.util.functionex.ThrowableFunction0_1<? extends Throwable,R>}
+     */
+    @SuppressWarnings("unchecked")
+    static <R> ThrowableFunction0_1<? extends Throwable, R> narrow(ThrowableFunction0_1<? extends Throwable, ? extends R> f) {
+        return (ThrowableFunction0_1<? extends Throwable, R>) f;
+    }
+
+    /**
+     * Returns a composed function that first applies this function, and then applies
+     * the {@code after} function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param after the function to apply after this function
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    default ThrowableFunction0_0<X> andConsumes(ThrowableFunction1_0<X, ? super R> after) {
+        Objects.requireNonNull(after);
+        return () -> after.apply(apply());
+    }
+    /**
+     * Returns a composed function that first applies this function to
+     * its input, and then applies the {@code after} function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <V> the type of output of the {@code after} function, and of the
+     *           composed function
+     * @param after the function to apply after this function is applied
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    default <V> ThrowableFunction0_1<X, V> andMap(ThrowableFunction1_1<X, ? super R, ? extends V> after) {
+        Objects.requireNonNull(after);
+        return () -> after.apply(apply());
+    }
+    /**
+     * Returns a composed function that first applies this function to
+     * its input, and then applies the {@code after} function resulting on an Entry.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <V1> the type of key of the result entry
+     * @param <V2> the type of value of the result entry
+     * @param after the function to apply after this function
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    @SuppressWarnings("unchecked")
+    default <V1, V2> ThrowableFunction0_2<X, V1, V2> andMapToEntry(ThrowableFunction1_2<X, ? super R, ? extends V1, ? extends V2> after) {
+        Objects.requireNonNull(after);
+        return () -> (Map.Entry<V1, V2>) after.apply(apply());
+    }
+
+    /**
+     * Returns a composed function that first applies the {@code before} function to
+     * its input, and then applies this function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param before the function to apply before this function is applied
+     * @return a composed function that first applies the {@code before} function and
+     * then applies this function
+     * @throws NullPointerException if before is null
+     */
+    default ThrowableFunction0_1<X, R> compose(ThrowableFunction0_0<X> before) {
+        Objects.requireNonNull(before);
+        return () -> {
+            before.apply();
+            return apply();
+        };
+    }
+    /**
+     * Returns a composed function that first applies the {@code before} function to
+     * its input, and then applies this function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param before the function to apply before this function is applied
+     * @return a composed function that first applies the {@code before} function and
+     * then applies this function
+     * @throws NullPointerException if before is null
+     */
+    default <T> ThrowableFunction1_1<X, T, R> compose(ThrowableFunction1_0<X, ? super T> before) {
+        Objects.requireNonNull(before);
+        return t1 -> {
+            before.apply(t1);
+            return apply();
+        };
+    }
+    /**
+     * Returns a composed function that first applies the {@code before} function to
+     * its input, and then applies this function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param before the function to apply before this function is applied
+     * @return a composed function that first applies the {@code before} function and
+     * then applies this function
+     * @throws NullPointerException if before is null
+     */
+    default <T1, T2> ThrowableFunction2_1<X, T1, T2, R> compose(ThrowableFunction2_0<X, ? super T1, ? super T2> before) {
+        Objects.requireNonNull(before);
+        return (t1, t2) -> {
+            before.apply(t1, t2);
+            return apply();
+        };
+    }
+
+}

--- a/src/main/java/one/util/functionex/ThrowableFunction0_1.java
+++ b/src/main/java/one/util/functionex/ThrowableFunction0_1.java
@@ -22,6 +22,7 @@ public interface ThrowableFunction0_1<X extends Throwable, R> extends Serializab
      * Gets a result.
      *
      * @return a result
+     * @throws X Exception that function may throw
      */
     R apply() throws X;
 
@@ -30,12 +31,13 @@ public interface ThrowableFunction0_1<X extends Throwable, R> extends Serializab
      * {@code one.util.functionex.ThrowableFunction0_1<? extends Throwable,R>}
      *
      * @param f A {@code one.util.functionex.ThrowableFunction0_1}
+     * @param <X>  Exception that f may declare to throw
      * @param <R> The return type
      * @return the given {@code f} instance as narrowed type {@code one.util.functionex.ThrowableFunction0_1<? extends Throwable,R>}
      */
     @SuppressWarnings("unchecked")
-    static <R> ThrowableFunction0_1<? extends Throwable, R> narrow(ThrowableFunction0_1<? extends Throwable, ? extends R> f) {
-        return (ThrowableFunction0_1<? extends Throwable, R>) f;
+    static <X extends Throwable, R> ThrowableFunction0_1<X, R> narrow(ThrowableFunction0_1<X, ? extends R> f) {
+        return (ThrowableFunction0_1<X, R>) f;
     }
 
     /**
@@ -86,7 +88,7 @@ public interface ThrowableFunction0_1<X extends Throwable, R> extends Serializab
     @SuppressWarnings("unchecked")
     default <V1, V2> ThrowableFunction0_2<X, V1, V2> andMapToEntry(ThrowableFunction1_2<X, ? super R, ? extends V1, ? extends V2> after) {
         Objects.requireNonNull(after);
-        return () -> (Map.Entry<V1, V2>) after.apply(apply());
+        return () -> (Tuple<V1, V2>) after.apply(apply());
     }
 
     /**
@@ -113,15 +115,16 @@ public interface ThrowableFunction0_1<X extends Throwable, R> extends Serializab
      * If evaluation of either function throws an exception, it is relayed to
      * the caller of the composed function.
      *
+     * @param <I> Type of parameter that take the before function
      * @param before the function to apply before this function is applied
      * @return a composed function that first applies the {@code before} function and
      * then applies this function
      * @throws NullPointerException if before is null
      */
-    default <T> ThrowableFunction1_1<X, T, R> compose(ThrowableFunction1_0<X, ? super T> before) {
+    default <I> ThrowableFunction1_1<X, I, R> compose(ThrowableFunction1_0<X, ? super I> before) {
         Objects.requireNonNull(before);
-        return t1 -> {
-            before.apply(t1);
+        return i1 -> {
+            before.apply(i1);
             return apply();
         };
     }
@@ -131,15 +134,17 @@ public interface ThrowableFunction0_1<X extends Throwable, R> extends Serializab
      * If evaluation of either function throws an exception, it is relayed to
      * the caller of the composed function.
      *
+     * @param <I1> Type of first parameter that take the before function
+     * @param <I2> Type of second parameter that take the before function
      * @param before the function to apply before this function is applied
      * @return a composed function that first applies the {@code before} function and
      * then applies this function
      * @throws NullPointerException if before is null
      */
-    default <T1, T2> ThrowableFunction2_1<X, T1, T2, R> compose(ThrowableFunction2_0<X, ? super T1, ? super T2> before) {
+    default <I1, I2> ThrowableFunction2_1<X, I1, I2, R> compose(ThrowableFunction2_0<X, ? super I1, ? super I2> before) {
         Objects.requireNonNull(before);
-        return (t1, t2) -> {
-            before.apply(t1, t2);
+        return (i1, i2) -> {
+            before.apply(i1, i2);
             return apply();
         };
     }

--- a/src/main/java/one/util/functionex/ThrowableFunction0_2.java
+++ b/src/main/java/one/util/functionex/ThrowableFunction0_2.java
@@ -22,21 +22,23 @@ public interface ThrowableFunction0_2<X extends Throwable, R1, R2> extends Seria
      * Gets 2 results in a Tuple.
      *
      * @return a @{@link Map.Entry} of 2 values
+     * @throws X Exception that function may throw
      */
-    Map.Entry<R1, R2> apply() throws X;
+    Tuple<R1, R2> apply() throws X;
 
     /**
      * Narrows the given {@code one.util.functionex.ThrowableFunction0_2<? extends Throwable, ? extends R1, ? extends R2>} to
      * {@code one.util.functionex.ThrowableFunction0_2<? extends Throwable,R1,R2>}
      *
      * @param f A {@code one.util.functionex.ThrowableFunction0_2}
+     * @param <X>  Exception that f may declare to throw
      * @param <R1> The first return type
      * @param <R2> The second return type
      * @return the given {@code f} instance as narrowed type {@code one.util.functionex.ThrowableFunction0_2<? extends Throwable,R1,R2>}
      */
     @SuppressWarnings("unchecked")
-    static <R1, R2> ThrowableFunction0_2<? extends Throwable, R1, R2> narrow(ThrowableFunction0_2<? extends Throwable, ? extends R1, ? extends R2> f) {
-        return (ThrowableFunction0_2<? extends Throwable, R1, R2>) f;
+    static <X extends Throwable, R1, R2> ThrowableFunction0_2<X, R1, R2> narrow(ThrowableFunction0_2<X, ? extends R1, ? extends R2> f) {
+        return (ThrowableFunction0_2<X, R1, R2>) f;
     }
 
     /**
@@ -95,8 +97,8 @@ public interface ThrowableFunction0_2<X extends Throwable, R1, R2> extends Seria
     default <V1, V2> ThrowableFunction0_2<X, V1, V2> andMap(ThrowableFunction2_2<X, ? super R1, ? super R2, ? extends V1, ? extends V2> after) {
         Objects.requireNonNull(after);
         return () -> {
-            Map.Entry<R1, R2> value = apply();
-            return (Map.Entry<V1, V2>) after.apply(value.getKey(), value.getValue());
+            Tuple<R1, R2> value = apply();
+            return (Tuple<V1, V2>) after.apply(value.getKey(), value.getValue());
         };
     }
 
@@ -124,16 +126,16 @@ public interface ThrowableFunction0_2<X extends Throwable, R1, R2> extends Seria
      * If evaluation of either function throws an exception, it is relayed to
      * the caller of the composed function.
      *
-     * @param <T> type of parameter of before function
+     * @param <I> type of parameter of before function
      * @param before the function to apply before this function is applied
      * @return a composed function that first applies the {@code before} function and
      * then applies this function
      * @throws NullPointerException if before is null
      */
-    default <T> ThrowableFunction1_2<X, T, R1, R2> compose(ThrowableFunction1_0<X, ? super T> before) {
+    default <I> ThrowableFunction1_2<X, I, R1, R2> compose(ThrowableFunction1_0<X, ? super I> before) {
         Objects.requireNonNull(before);
-        return t1 -> {
-            before.apply(t1);
+        return i1 -> {
+            before.apply(i1);
             return apply();
         };
     }
@@ -143,17 +145,17 @@ public interface ThrowableFunction0_2<X extends Throwable, R1, R2> extends Seria
      * If evaluation of either function throws an exception, it is relayed to
      * the caller of the composed function.
      *
-     * @param <T1> type of first parameter of before function
-     * @param <T2> type of second parameter of before function
+     * @param <I1> type of first parameter of before function
+     * @param <I2> type of second parameter of before function
      * @param before the function to apply before this function is applied
      * @return a composed function that first applies the {@code before} function and
      * then applies this function
      * @throws NullPointerException if before is null
      */
-    default <T1, T2> ThrowableFunction2_2<X, T1, T2, R1, R2> compose(ThrowableFunction2_0<X, ? super T1, ? super T2> before) {
+    default <I1, I2> ThrowableFunction2_2<X, I1, I2, R1, R2> compose(ThrowableFunction2_0<X, ? super I1, ? super I2> before) {
         Objects.requireNonNull(before);
-        return (t1, t2) -> {
-            before.apply(t1, t2);
+        return (i1, i2) -> {
+            before.apply(i1, i2);
             return apply();
         };
     }

--- a/src/main/java/one/util/functionex/ThrowableFunction0_2.java
+++ b/src/main/java/one/util/functionex/ThrowableFunction0_2.java
@@ -1,0 +1,161 @@
+package one.util.functionex;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents a function with no arguments and returning two values.
+ *
+ * @param <X> the exception which may throw
+ * @param <R1> return type 1 of the function
+ * @param <R2> return type 2 of the function
+ */
+@FunctionalInterface
+public interface ThrowableFunction0_2<X extends Throwable, R1, R2> extends Serializable {
+    /**
+     * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.
+     */
+    long serialVersionUID = 1L;
+
+    /**
+     * Gets 2 results in a Tuple.
+     *
+     * @return a @{@link Map.Entry} of 2 values
+     */
+    Map.Entry<R1, R2> apply() throws X;
+
+    /**
+     * Narrows the given {@code one.util.functionex.ThrowableFunction0_2<? extends Throwable, ? extends R1, ? extends R2>} to
+     * {@code one.util.functionex.ThrowableFunction0_2<? extends Throwable,R1,R2>}
+     *
+     * @param f A {@code one.util.functionex.ThrowableFunction0_2}
+     * @param <R1> The first return type
+     * @param <R2> The second return type
+     * @return the given {@code f} instance as narrowed type {@code one.util.functionex.ThrowableFunction0_2<? extends Throwable,R1,R2>}
+     */
+    @SuppressWarnings("unchecked")
+    static <R1, R2> ThrowableFunction0_2<? extends Throwable, R1, R2> narrow(ThrowableFunction0_2<? extends Throwable, ? extends R1, ? extends R2> f) {
+        return (ThrowableFunction0_2<? extends Throwable, R1, R2>) f;
+    }
+
+    /**
+     * Returns a composed function that first applies this function to
+     * its input, and then applies the {@code after} function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param after the function to apply after this function is applied
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    default ThrowableFunction0_0<X> andConsumes(ThrowableFunction2_0<X, ? super R1, ? super R2> after) {
+        Objects.requireNonNull(after);
+        return () -> {
+            Map.Entry<R1, R2> value = apply();
+            after.apply(value.getKey(), value.getValue());
+        };
+    }
+    /**
+     * Returns a composed function that first applies this function to
+     * its input, and then applies the {@code after} function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <V> the type of the result of the {@code after} function
+     *
+     * @param after the function to apply after this function is applied
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    default <V> ThrowableFunction0_1<X, V> andReduce(ThrowableFunction2_1<X, ? super R1, ? super R2, ? extends V> after) {
+        Objects.requireNonNull(after);
+        return () -> {
+            Map.Entry<R1, R2> value = apply();
+            return after.apply(value.getKey(), value.getValue());
+        };
+    }
+    /**
+     * Returns a composed function that first applies this function to
+     * its input, and then applies the {@code after} function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <V1> the type of the first output of the {@code after} function
+     * @param <V2> the type of the second output of the {@code after} function
+     *
+     * @param after the function to apply after this function is applied
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    @SuppressWarnings("unchecked")
+    default <V1, V2> ThrowableFunction0_2<X, V1, V2> andMap(ThrowableFunction2_2<X, ? super R1, ? super R2, ? extends V1, ? extends V2> after) {
+        Objects.requireNonNull(after);
+        return () -> {
+            Map.Entry<R1, R2> value = apply();
+            return (Map.Entry<V1, V2>) after.apply(value.getKey(), value.getValue());
+        };
+    }
+
+    /**
+     * Returns a composed function that first applies the {@code before} function to
+     * its input, and then applies this function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param before the function to apply before this function is applied
+     * @return a composed function that first applies the {@code before} function and
+     * then applies this function
+     * @throws NullPointerException if before is null
+     */
+    default ThrowableFunction0_2<X, R1, R2> compose(ThrowableFunction0_0<X> before) {
+        Objects.requireNonNull(before);
+        return () -> {
+            before.apply();
+            return apply();
+        };
+    }
+    /**
+     * Returns a composed function that first applies the {@code before} function to
+     * its input, and then applies this function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <T> type of parameter of before function
+     * @param before the function to apply before this function is applied
+     * @return a composed function that first applies the {@code before} function and
+     * then applies this function
+     * @throws NullPointerException if before is null
+     */
+    default <T> ThrowableFunction1_2<X, T, R1, R2> compose(ThrowableFunction1_0<X, ? super T> before) {
+        Objects.requireNonNull(before);
+        return t1 -> {
+            before.apply(t1);
+            return apply();
+        };
+    }
+    /**
+     * Returns a composed function that first applies the {@code before} function to
+     * its input, and then applies this function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <T1> type of first parameter of before function
+     * @param <T2> type of second parameter of before function
+     * @param before the function to apply before this function is applied
+     * @return a composed function that first applies the {@code before} function and
+     * then applies this function
+     * @throws NullPointerException if before is null
+     */
+    default <T1, T2> ThrowableFunction2_2<X, T1, T2, R1, R2> compose(ThrowableFunction2_0<X, ? super T1, ? super T2> before) {
+        Objects.requireNonNull(before);
+        return (t1, t2) -> {
+            before.apply(t1, t2);
+            return apply();
+        };
+    }
+
+}

--- a/src/main/java/one/util/functionex/ThrowableFunction1_0.java
+++ b/src/main/java/one/util/functionex/ThrowableFunction1_0.java
@@ -20,6 +20,7 @@ public interface ThrowableFunction1_0<X extends Throwable, T> extends Serializab
      * Performs this operation on the given argument.
      *
      * @param t the input argument
+     * @throws X Exception that function may throw
      */
     void apply(T t) throws X;
 
@@ -28,12 +29,13 @@ public interface ThrowableFunction1_0<X extends Throwable, T> extends Serializab
      * {@code one.util.functionex.ThrowableFunction1_0<? extends Throwable,T1>}
      *
      * @param f A {@code one.util.functionex.ThrowableFunction1_0}
-     * @param <T1> The parameter type
+     * @param <X>  Exception that f may declare to throw
+     * @param <T> The parameter type
      * @return the given {@code f} instance as narrowed type {@code one.util.functionex.ThrowableFunction1_0<? extends Throwable,T1>}
      */
     @SuppressWarnings("unchecked")
-    static <T1> ThrowableFunction1_0<? extends Throwable, T1> narrow(ThrowableFunction1_0<? extends Throwable, ? super T1> f) {
-        return (ThrowableFunction1_0<? extends Throwable, T1>) f;
+    static <X extends Throwable, T> ThrowableFunction1_0<X, T> narrow(ThrowableFunction1_0<X, ? super T> f) {
+        return (ThrowableFunction1_0<X, T>) f;
     }
 
     /**
@@ -60,6 +62,7 @@ public interface ThrowableFunction1_0<X extends Throwable, T> extends Serializab
      * If evaluation of either function throws an exception, it is relayed to
      * the caller of the composed function.
      *
+     * @param <V> the type of the result of the {@code after} function
      * @param after the function to apply after this function is applied
      * @return a composed function that first applies this function and then
      * applies the {@code after} function
@@ -78,6 +81,8 @@ public interface ThrowableFunction1_0<X extends Throwable, T> extends Serializab
      * If evaluation of either function throws an exception, it is relayed to
      * the caller of the composed function.
      *
+     * @param <V1> the type of key of the result entry
+     * @param <V2> the type of value of the result entry
      * @param after the function to apply after this function is applied
      * @return a composed function that first applies this function and then
      * applies the {@code after} function
@@ -114,37 +119,34 @@ public interface ThrowableFunction1_0<X extends Throwable, T> extends Serializab
      * If evaluation of either function throws an exception, it is relayed to
      * the caller of the composed function.
      *
-     * @param <E> type of parameter of before function
+     * @param <I> type of parameter of before function
      * @param before the function to apply before this function is applied
      * @return a composed function that first applies the {@code before} function and
      * then applies this function
      * @throws NullPointerException if before is null
      */
-    default <E> ThrowableFunction1_0<X, E> compose(ThrowableFunction1_1<X, ? super E, ? extends T> before) {
+    default <I> ThrowableFunction1_0<X, I> compose(ThrowableFunction1_1<X, ? super I, ? extends T> before) {
         Objects.requireNonNull(before);
-        return t1 -> {
-            apply(before.apply(t1));
+        return i1 -> {
+            apply(before.apply(i1));
         };
     }
-//    /**
-//     * Returns a composed function that first applies the {@code before} function to
-//     * its input, and then applies this function to the result.
-//     * If evaluation of either function throws an exception, it is relayed to
-//     * the caller of the composed function.
-//     *
-//     * @param <T1> type of first parameter of before function
-//     * @param <T2> type of second parameter of before function
-//     * @param before the function to apply before this function is applied
-//     * @return a composed function that first applies the {@code before} function and
-//     * then applies this function
-//     * @throws NullPointerException if before is null
-//     */
-//    default <T1, T2> ThrowableFunction2_2<X, T1, T2, R1, R2> compose(ThrowableFunction2_0<X, ? super T1, ? super T2> before) {
-//        Objects.requireNonNull(before);
-//        return (t1, t2) -> {
-//            before.apply(t1, t2);
-//            return apply();
-//        };
-//    }
+    /**
+     * Returns a composed function that first applies the {@code before} function to
+     * its input, and then applies this function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <I1> type of first parameter of before function
+     * @param <I2> type of second parameter of before function
+     * @param before the function to apply before this function is applied
+     * @return a composed function that first applies the {@code before} function and
+     * then applies this function
+     * @throws NullPointerException if before is null
+     */
+    default <I1, I2> ThrowableFunction2_0<X, I1, I2> compose(ThrowableFunction2_1<X, ? super I1, ? super I2, ? extends T> before) {
+        Objects.requireNonNull(before);
+        return (i1, i2) -> apply(before.apply(i1, i2));
+    }
 
 }

--- a/src/main/java/one/util/functionex/ThrowableFunction1_0.java
+++ b/src/main/java/one/util/functionex/ThrowableFunction1_0.java
@@ -1,0 +1,150 @@
+package one.util.functionex;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Represents a function with one argument and no returning values.
+ *
+ * @param <X> the exception which may throw
+ * @param <T> argument 1 of the function
+ */
+@FunctionalInterface
+public interface ThrowableFunction1_0<X extends Throwable, T> extends Serializable {
+    /**
+     * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.
+     */
+    long serialVersionUID = 1L;
+
+    /**
+     * Performs this operation on the given argument.
+     *
+     * @param t the input argument
+     */
+    void apply(T t) throws X;
+
+    /**
+     * Narrows the given {@code one.util.functionex.ThrowableFunction1_0<? extends Throwable, ? super T1>} to
+     * {@code one.util.functionex.ThrowableFunction1_0<? extends Throwable,T1>}
+     *
+     * @param f A {@code one.util.functionex.ThrowableFunction1_0}
+     * @param <T1> The parameter type
+     * @return the given {@code f} instance as narrowed type {@code one.util.functionex.ThrowableFunction1_0<? extends Throwable,T1>}
+     */
+    @SuppressWarnings("unchecked")
+    static <T1> ThrowableFunction1_0<? extends Throwable, T1> narrow(ThrowableFunction1_0<? extends Throwable, ? super T1> f) {
+        return (ThrowableFunction1_0<? extends Throwable, T1>) f;
+    }
+
+    /**
+     * Returns a composed function that first applies this function to
+     * its input, and then applies the {@code after} function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param after the function to apply after this function is applied
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    default ThrowableFunction1_0<X, T> andRun(ThrowableFunction0_0<X> after) {
+        Objects.requireNonNull(after);
+        return t -> {
+            apply(t);
+            after.apply();
+        };
+    }
+    /**
+     * Returns a composed function that first applies this function to
+     * its input, and then applies the {@code after} function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param after the function to apply after this function is applied
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    default <V> ThrowableFunction1_1<X, T, V> andSupply(ThrowableFunction0_1<X, V> after) {
+        Objects.requireNonNull(after);
+        return t -> {
+            apply(t);
+            return after.apply();
+        };
+    }
+    /**
+     * Returns a composed function that first applies this function to
+     * its input, and then applies the {@code after} function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param after the function to apply after this function is applied
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    default <V1, V2> ThrowableFunction1_2<X, T, V1, V2> andSupplyEntry(ThrowableFunction0_2<X, V1, V2> after) {
+        Objects.requireNonNull(after);
+        return t -> {
+            apply(t);
+            return after.apply();
+        };
+    }
+
+    /**
+     * Returns a composed function that first applies the {@code before} function to
+     * its input, and then applies this function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param before the function to apply before this function is applied
+     * @return a composed function that first applies the {@code before} function and
+     * then applies this function
+     * @throws NullPointerException if before is null
+     */
+    default ThrowableFunction0_0<X> compose(ThrowableFunction0_1<X, ? extends T> before) {
+        Objects.requireNonNull(before);
+        return () -> {
+            apply(before.apply());
+        };
+    }
+    /**
+     * Returns a composed function that first applies the {@code before} function to
+     * its input, and then applies this function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <E> type of parameter of before function
+     * @param before the function to apply before this function is applied
+     * @return a composed function that first applies the {@code before} function and
+     * then applies this function
+     * @throws NullPointerException if before is null
+     */
+    default <E> ThrowableFunction1_0<X, E> compose(ThrowableFunction1_1<X, ? super E, ? extends T> before) {
+        Objects.requireNonNull(before);
+        return t1 -> {
+            apply(before.apply(t1));
+        };
+    }
+//    /**
+//     * Returns a composed function that first applies the {@code before} function to
+//     * its input, and then applies this function to the result.
+//     * If evaluation of either function throws an exception, it is relayed to
+//     * the caller of the composed function.
+//     *
+//     * @param <T1> type of first parameter of before function
+//     * @param <T2> type of second parameter of before function
+//     * @param before the function to apply before this function is applied
+//     * @return a composed function that first applies the {@code before} function and
+//     * then applies this function
+//     * @throws NullPointerException if before is null
+//     */
+//    default <T1, T2> ThrowableFunction2_2<X, T1, T2, R1, R2> compose(ThrowableFunction2_0<X, ? super T1, ? super T2> before) {
+//        Objects.requireNonNull(before);
+//        return (t1, t2) -> {
+//            before.apply(t1, t2);
+//            return apply();
+//        };
+//    }
+
+}

--- a/src/main/java/one/util/functionex/ThrowableFunction1_1.java
+++ b/src/main/java/one/util/functionex/ThrowableFunction1_1.java
@@ -1,0 +1,70 @@
+package one.util.functionex;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Represents a function with one argument and returning one value.
+ *
+ * @param <X> the exception which may throw
+ * @param <T1> argument 1 of the function
+ * @param <R1> return type 1 of the function
+ */
+@FunctionalInterface
+public interface ThrowableFunction1_1<X extends Throwable, T1, R1> extends Serializable {
+    /**
+     * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.
+     */
+    long serialVersionUID = 1L;
+
+    /**
+     * Applies this function to the given argument.
+     *
+     * @param t1 the function argument
+     * @return the function result
+     */
+    R1 apply(T1 t1) throws X;
+
+
+    /**
+     * Narrows the given {@code one.util.functionex.ThrowableFunction1_1<? extends Throwable, ? super T1, ? extends R1>} to
+     * {@code one.util.functionex.ThrowableFunction1_1<? extends Throwable,T1,R1>}
+     *
+     * @param f A {@code one.util.functionex.ThrowableFunction1_1}
+     * @param <T1> The parameter type
+     * @param <R1> The return type
+     * @return the given {@code f} instance as narrowed type {@code one.util.functionex.ThrowableFunction1_1<? extends Throwable,T1,R1>}
+     */
+    @SuppressWarnings("unchecked")
+    static <T1, R1> ThrowableFunction1_1<? extends Throwable, T1, R1> narrow(ThrowableFunction1_1<? extends Throwable, ? super T1, ? extends R1> f) {
+        return (ThrowableFunction1_1<? extends Throwable, T1, R1>) f;
+    }
+
+    /**
+     * Returns the identity one.util.functionex.ThrowableFunction1_1, i.e. the function that returns its input.
+     *
+     * @param <T> argument type (and return type) of the identity function
+     * @return the identity one.util.functionex.ThrowableFunction1_1
+     */
+    static <X extends Throwable, T> ThrowableFunction1_1<X, T, T> identity() {
+        return t -> t;
+    }
+
+    /**
+     * Returns a composed function that first applies this function to
+     * its input, and then applies the {@code after} function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <V> the type of output of the {@code after} function
+     *
+     * @param after the function to apply after this function is applied
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    default <V> ThrowableFunction1_1<X, T1, V> andThen(ThrowableFunction1_1<X, ? super R1, ? extends V> after) {
+        Objects.requireNonNull(after);
+        return t1 -> after.apply(apply(t1));
+    }
+}

--- a/src/main/java/one/util/functionex/ThrowableFunction1_1.java
+++ b/src/main/java/one/util/functionex/ThrowableFunction1_1.java
@@ -7,11 +7,11 @@ import java.util.Objects;
  * Represents a function with one argument and returning one value.
  *
  * @param <X> the exception which may throw
- * @param <T1> argument 1 of the function
- * @param <R1> return type 1 of the function
+ * @param <T> argument 1 of the function
+ * @param <R> return type 1 of the function
  */
 @FunctionalInterface
-public interface ThrowableFunction1_1<X extends Throwable, T1, R1> extends Serializable {
+public interface ThrowableFunction1_1<X extends Throwable, T, R> extends Serializable {
     /**
      * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.
      */
@@ -20,10 +20,11 @@ public interface ThrowableFunction1_1<X extends Throwable, T1, R1> extends Seria
     /**
      * Applies this function to the given argument.
      *
-     * @param t1 the function argument
+     * @param t the function argument
      * @return the function result
+     * @throws X Exception that function may throw
      */
-    R1 apply(T1 t1) throws X;
+    R apply(T t) throws X;
 
 
     /**
@@ -31,18 +32,20 @@ public interface ThrowableFunction1_1<X extends Throwable, T1, R1> extends Seria
      * {@code one.util.functionex.ThrowableFunction1_1<? extends Throwable,T1,R1>}
      *
      * @param f A {@code one.util.functionex.ThrowableFunction1_1}
-     * @param <T1> The parameter type
-     * @param <R1> The return type
+     * @param <X>  Exception that f may declare to throw
+     * @param <T> The parameter type
+     * @param <R> The return type
      * @return the given {@code f} instance as narrowed type {@code one.util.functionex.ThrowableFunction1_1<? extends Throwable,T1,R1>}
      */
     @SuppressWarnings("unchecked")
-    static <T1, R1> ThrowableFunction1_1<? extends Throwable, T1, R1> narrow(ThrowableFunction1_1<? extends Throwable, ? super T1, ? extends R1> f) {
-        return (ThrowableFunction1_1<? extends Throwable, T1, R1>) f;
+    static <X extends Throwable, T, R> ThrowableFunction1_1<X, T, R> narrow(ThrowableFunction1_1<X, ? super T, ? extends R> f) {
+        return (ThrowableFunction1_1<X, T, R>) f;
     }
 
     /**
      * Returns the identity one.util.functionex.ThrowableFunction1_1, i.e. the function that returns its input.
      *
+     * @param <X> Exception type function returned may throw
      * @param <T> argument type (and return type) of the identity function
      * @return the identity one.util.functionex.ThrowableFunction1_1
      */
@@ -56,15 +59,96 @@ public interface ThrowableFunction1_1<X extends Throwable, T1, R1> extends Seria
      * If evaluation of either function throws an exception, it is relayed to
      * the caller of the composed function.
      *
-     * @param <V> the type of output of the {@code after} function
-     *
      * @param after the function to apply after this function is applied
      * @return a composed function that first applies this function and then
      * applies the {@code after} function
      * @throws NullPointerException if after is null
      */
-    default <V> ThrowableFunction1_1<X, T1, V> andThen(ThrowableFunction1_1<X, ? super R1, ? extends V> after) {
+    default ThrowableFunction1_0<X, T> andConsume(ThrowableFunction1_0<X, ? super R> after) {
         Objects.requireNonNull(after);
-        return t1 -> after.apply(apply(t1));
+        return t -> after.apply(apply(t));
     }
+    /**
+     * Returns a composed function that first applies this function to
+     * its input, and then applies the {@code after} function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <V> the type of the result of the {@code after} function
+     * @param after the function to apply after this function is applied
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    default <V> ThrowableFunction1_1<X, T, V> andMap(ThrowableFunction1_1<X, ? super R, ? extends V> after) {
+        Objects.requireNonNull(after);
+        return t -> after.apply(apply(t));
+    }
+    /**
+     * Returns a composed function that first applies this function to
+     * its input, and then applies the {@code after} function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <V1> the type of key of the result entry
+     * @param <V2> the type of value of the result entry
+     * @param after the function to apply after this function is applied
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    default <V1, V2> ThrowableFunction1_2<X, T, V1, V2> andMapToEntry(ThrowableFunction1_2<X, ? super R, V1, V2> after) {
+        Objects.requireNonNull(after);
+        return t -> after.apply(apply(t));
+    }
+
+    /**
+     * Returns a composed function that first applies the {@code before} function to
+     * its input, and then applies this function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param before the function to apply before this function is applied
+     * @return a composed function that first applies the {@code before} function and
+     * then applies this function
+     * @throws NullPointerException if before is null
+     */
+    default ThrowableFunction0_1<X, R> compose(ThrowableFunction0_1<X, ? extends T> before) {
+        Objects.requireNonNull(before);
+        return () -> apply(before.apply());
+    }
+    /**
+     * Returns a composed function that first applies the {@code before} function to
+     * its input, and then applies this function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <I> type of parameter of before function
+     * @param before the function to apply before this function is applied
+     * @return a composed function that first applies the {@code before} function and
+     * then applies this function
+     * @throws NullPointerException if before is null
+     */
+    default <I> ThrowableFunction1_1<X, I, R> compose(ThrowableFunction1_1<X, ? super I, ? extends T> before) {
+        Objects.requireNonNull(before);
+        return i1 -> apply(before.apply(i1));
+    }
+    /**
+     * Returns a composed function that first applies the {@code before} function to
+     * its input, and then applies this function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <I1> type of first parameter of before function
+     * @param <I2> type of second parameter of before function
+     * @param before the function to apply before this function is applied
+     * @return a composed function that first applies the {@code before} function and
+     * then applies this function
+     * @throws NullPointerException if before is null
+     */
+    default <I1, I2> ThrowableFunction2_1<X, I1, I2, R> compose(ThrowableFunction2_1<X, ? super I1, ? super I2, ? extends T> before) {
+        Objects.requireNonNull(before);
+        return (i1, i2) -> apply(before.apply(i1, i2));
+    }
+
 }

--- a/src/main/java/one/util/functionex/ThrowableFunction1_2.java
+++ b/src/main/java/one/util/functionex/ThrowableFunction1_2.java
@@ -1,0 +1,68 @@
+package one.util.functionex;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents a function with one argument and returning two values.
+ *
+ * @param <X> the exception which may throw
+ * @param <T1> argument 1 of the function
+ * @param <R1> return type 1 of the function
+ * @param <R2> return type 2 of the function
+ */
+@FunctionalInterface
+public interface ThrowableFunction1_2<X extends Throwable, T1, R1, R2> extends Serializable {
+    /**
+     * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.
+     */
+    long serialVersionUID = 1L;
+
+    /**
+     * Applies this function to the given argument and returns a Tuple of 2 values.
+     *
+     * @param t1 the function argument
+     * @return a @{@link Map.Entry} of 2 values
+     */
+    Map.Entry<R1, R2> apply(T1 t1) throws X;
+
+    /**
+     * Narrows the given {@code one.util.functionex.ThrowableFunction1_2<? extends Throwable, ? super T1, ? extends R1, ? extends R2>} to
+     * {@code one.util.functionex.ThrowableFunction1_2<? extends Throwable,T1,R1,R2>}
+     *
+     * @param f A {@code one.util.functionex.ThrowableFunction1_2}
+     * @param <T1> The parameter type
+     * @param <R1> The first return type
+     * @param <R2> The second return type
+     * @return the given {@code f} instance as narrowed type {@code one.util.functionex.ThrowableFunction1_2<? extends Throwable,T1,R1,R2>}
+     */
+    @SuppressWarnings("unchecked")
+    static <T1, R1, R2> ThrowableFunction1_2<? extends Throwable, T1, R1, R2> narrow(ThrowableFunction1_2<? extends Throwable, ? super T1, ? extends R1, ? extends R2> f) {
+        return (ThrowableFunction1_2<? extends Throwable, T1, R1, R2>) f;
+    }
+
+    /**
+     * Returns a composed function that first applies this function to
+     * its input, and then applies the {@code after} function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <V1> the type of the first output of the {@code after} function
+     * @param <V2> the type of the second output of the {@code after} function
+     *
+     * @param after the function to apply after this function is applied
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    @SuppressWarnings("unchecked")
+    default <V1, V2> ThrowableFunction1_2<X, T1, V1, V2> andThen(ThrowableFunction2_2<X, ? super R1, ? super R2, ? extends V1, ? extends V2> after) {
+        Objects.requireNonNull(after);
+        return t1 -> {
+            Map.Entry<R1, R2> value = apply(t1);
+            return (Map.Entry<V1, V2>) after.apply(value.getKey(), value.getValue());
+        };
+    }
+
+}

--- a/src/main/java/one/util/functionex/ThrowableFunction1_2.java
+++ b/src/main/java/one/util/functionex/ThrowableFunction1_2.java
@@ -8,12 +8,12 @@ import java.util.Objects;
  * Represents a function with one argument and returning two values.
  *
  * @param <X> the exception which may throw
- * @param <T1> argument 1 of the function
+ * @param <T> argument 1 of the function
  * @param <R1> return type 1 of the function
  * @param <R2> return type 2 of the function
  */
 @FunctionalInterface
-public interface ThrowableFunction1_2<X extends Throwable, T1, R1, R2> extends Serializable {
+public interface ThrowableFunction1_2<X extends Throwable, T, R1, R2> extends Serializable {
     /**
      * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.
      */
@@ -22,24 +22,26 @@ public interface ThrowableFunction1_2<X extends Throwable, T1, R1, R2> extends S
     /**
      * Applies this function to the given argument and returns a Tuple of 2 values.
      *
-     * @param t1 the function argument
-     * @return a @{@link Map.Entry} of 2 values
+     * @param t the function argument
+     * @return a @{@link Tuple} of 2 values
+     * @throws X Exception that function may throw
      */
-    Map.Entry<R1, R2> apply(T1 t1) throws X;
+    Tuple<R1, R2> apply(T t) throws X;
 
     /**
      * Narrows the given {@code one.util.functionex.ThrowableFunction1_2<? extends Throwable, ? super T1, ? extends R1, ? extends R2>} to
      * {@code one.util.functionex.ThrowableFunction1_2<? extends Throwable,T1,R1,R2>}
      *
      * @param f A {@code one.util.functionex.ThrowableFunction1_2}
-     * @param <T1> The parameter type
+     * @param <X>  Exception that f may declare to throw
+     * @param <T> The parameter type
      * @param <R1> The first return type
      * @param <R2> The second return type
      * @return the given {@code f} instance as narrowed type {@code one.util.functionex.ThrowableFunction1_2<? extends Throwable,T1,R1,R2>}
      */
     @SuppressWarnings("unchecked")
-    static <T1, R1, R2> ThrowableFunction1_2<? extends Throwable, T1, R1, R2> narrow(ThrowableFunction1_2<? extends Throwable, ? super T1, ? extends R1, ? extends R2> f) {
-        return (ThrowableFunction1_2<? extends Throwable, T1, R1, R2>) f;
+    static <X extends Throwable, T, R1, R2> ThrowableFunction1_2<X, T, R1, R2> narrow(ThrowableFunction1_2<X, ? super T, ? extends R1, ? extends R2> f) {
+        return (ThrowableFunction1_2<X, T, R1, R2>) f;
     }
 
     /**
@@ -48,21 +50,107 @@ public interface ThrowableFunction1_2<X extends Throwable, T1, R1, R2> extends S
      * If evaluation of either function throws an exception, it is relayed to
      * the caller of the composed function.
      *
-     * @param <V1> the type of the first output of the {@code after} function
-     * @param <V2> the type of the second output of the {@code after} function
+     * @param after the function to apply after this function is applied
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    default ThrowableFunction1_0<X, T> andConsume(ThrowableFunction2_0<X, ? super R1, ? super R2> after) {
+        Objects.requireNonNull(after);
+        return t -> {
+            Tuple<R1, R2> tuple = apply(t);
+            after.apply(tuple.t1(), tuple.t2());
+        };
+    }
+    /**
+     * Returns a composed function that first applies this function to
+     * its input, and then applies the {@code after} function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
      *
+     * @param <V> the type of the result of the {@code after} function
+     * @param after the function to apply after this function is applied
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    default <V> ThrowableFunction1_1<X, T, V> andReduce(ThrowableFunction2_1<X, ? super R1, ? super R2, ? extends V> after) {
+        Objects.requireNonNull(after);
+        return t -> {
+            Map.Entry<R1, R2> entry = apply(t);
+            return after.apply(entry.getKey(), entry.getValue());
+        };
+    }
+    /**
+     * Returns a composed function that first applies this function to
+     * its input, and then applies the {@code after} function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <V1> the type of key of the result entry
+     * @param <V2> the type of value of the result entry
      * @param after the function to apply after this function is applied
      * @return a composed function that first applies this function and then
      * applies the {@code after} function
      * @throws NullPointerException if after is null
      */
     @SuppressWarnings("unchecked")
-    default <V1, V2> ThrowableFunction1_2<X, T1, V1, V2> andThen(ThrowableFunction2_2<X, ? super R1, ? super R2, ? extends V1, ? extends V2> after) {
+    default <V1, V2> ThrowableFunction1_2<X, T, V1, V2> andMap(ThrowableFunction2_2<X, ? super R1, ? super R2, ? extends V1, ? extends V2> after) {
         Objects.requireNonNull(after);
-        return t1 -> {
-            Map.Entry<R1, R2> value = apply(t1);
-            return (Map.Entry<V1, V2>) after.apply(value.getKey(), value.getValue());
+        return t -> {
+            Map.Entry<R1, R2> entry = apply(t);
+            return (Tuple<V1, V2>) after.apply(entry.getKey(), entry.getValue());
         };
     }
+
+    /**
+     * Returns a composed function that first applies the {@code before} function to
+     * its input, and then applies this function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param before the function to apply before this function is applied
+     * @return a composed function that first applies the {@code before} function and
+     * then applies this function
+     * @throws NullPointerException if before is null
+     */
+    default ThrowableFunction0_2<X, R1, R2> compose(ThrowableFunction0_1<X, ? extends T> before) {
+        Objects.requireNonNull(before);
+        return () -> apply(before.apply());
+    }
+    /**
+     * Returns a composed function that first applies the {@code before} function to
+     * its input, and then applies this function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <I> type of parameter of before function
+     * @param before the function to apply before this function is applied
+     * @return a composed function that first applies the {@code before} function and
+     * then applies this function
+     * @throws NullPointerException if before is null
+     */
+    default <I> ThrowableFunction1_2<X, I, R1, R2> compose(ThrowableFunction1_1<X, ? super I, ? extends T> before) {
+        Objects.requireNonNull(before);
+        return i1 -> apply(before.apply(i1));
+    }
+    /**
+     * Returns a composed function that first applies the {@code before} function to
+     * its input, and then applies this function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <I1> type of first parameter of before function
+     * @param <I2> type of second parameter of before function
+     * @param before the function to apply before this function is applied
+     * @return a composed function that first applies the {@code before} function and
+     * then applies this function
+     * @throws NullPointerException if before is null
+     */
+    default <I1, I2> ThrowableFunction2_2<X, I1, I2, R1, R2> compose(ThrowableFunction2_1<X, ? super I1, ? super I2, ? extends T> before) {
+        Objects.requireNonNull(before);
+        return (i1, i2) -> apply(before.apply(i1, i2));
+    }
+
 
 }

--- a/src/main/java/one/util/functionex/ThrowableFunction2_0.java
+++ b/src/main/java/one/util/functionex/ThrowableFunction2_0.java
@@ -1,0 +1,61 @@
+package one.util.functionex;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Represents a function with two arguments and no returning values.
+ *
+ * @param <X> the exception which may throw
+ * @param <T1> argument 1 of the function
+ * @param <T2> argument 2 of the function
+ */
+@FunctionalInterface
+public interface ThrowableFunction2_0<X extends Throwable, T1, T2> extends Serializable {
+    /**
+     * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.
+     */
+    long serialVersionUID = 1L;
+
+    /**
+     * Performs this operation on the given arguments.
+     *
+     * @param t1 first input argument
+     * @param t2 second input argument
+     */
+    void apply(T1 t1, T2 t2) throws X;
+
+
+    /**
+     * Narrows the given {@code one.util.functionex.ThrowableFunction2_0<? extends Throwable, ? super T1, ? super T2>} to
+     * {@code one.util.functionex.ThrowableFunction2_0<? extends Throwable,T1,T2>}
+     *
+     * @param f A {@code one.util.functionex.ThrowableFunction2_0}
+     * @param <T1> The first parameter type
+     * @param <T2> The second parameter type
+     * @return the given {@code f} instance as narrowed type {@code one.util.functionex.ThrowableFunction2_0<? extends Throwable,T1,T2>}
+     */
+    @SuppressWarnings("unchecked")
+    static <T1, T2> ThrowableFunction2_0<? extends Throwable, T1, T2> narrow(ThrowableFunction2_0<? extends Throwable, ? super T1, ? super T2> f) {
+        return (ThrowableFunction2_0<? extends Throwable, T1, T2>) f;
+    }
+
+    /**
+     * Returns a composed function that first applies this function to
+     * its input, and then applies the {@code after} function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param after the function to apply after this function is applied
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    default ThrowableFunction2_0<X, T1, T2> andThen(ThrowableFunction0_0<X> after) {
+        Objects.requireNonNull(after);
+        return (T1 t1, T2 t2) -> {
+            apply(t1, t2);
+            after.apply();
+        };
+    }
+}

--- a/src/main/java/one/util/functionex/ThrowableFunction2_0.java
+++ b/src/main/java/one/util/functionex/ThrowableFunction2_0.java
@@ -1,6 +1,7 @@
 package one.util.functionex;
 
 import java.io.Serializable;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -22,6 +23,7 @@ public interface ThrowableFunction2_0<X extends Throwable, T1, T2> extends Seria
      *
      * @param t1 first input argument
      * @param t2 second input argument
+     * @throws X Exception that function may throw
      */
     void apply(T1 t1, T2 t2) throws X;
 
@@ -31,18 +33,29 @@ public interface ThrowableFunction2_0<X extends Throwable, T1, T2> extends Seria
      * {@code one.util.functionex.ThrowableFunction2_0<? extends Throwable,T1,T2>}
      *
      * @param f A {@code one.util.functionex.ThrowableFunction2_0}
+     * @param <X>  Exception that f may declare to throw
      * @param <T1> The first parameter type
      * @param <T2> The second parameter type
      * @return the given {@code f} instance as narrowed type {@code one.util.functionex.ThrowableFunction2_0<? extends Throwable,T1,T2>}
      */
     @SuppressWarnings("unchecked")
-    static <T1, T2> ThrowableFunction2_0<? extends Throwable, T1, T2> narrow(ThrowableFunction2_0<? extends Throwable, ? super T1, ? super T2> f) {
-        return (ThrowableFunction2_0<? extends Throwable, T1, T2>) f;
+    static <X extends Throwable, T1, T2> ThrowableFunction2_0<X, T1, T2> narrow(ThrowableFunction2_0<X, ? super T1, ? super T2> f) {
+        return (ThrowableFunction2_0<X, T1, T2>) f;
+    }
+
+    /**
+     * Applies this function to the given arguments wrapped in a Tuple of 2 values.
+     *
+     * @param value tuple of 2 function argument
+     * @throws X Exception that function may throw
+     */
+    default void apply(Map.Entry<T1, T2> value) throws X {
+        apply(value.getKey(), value.getValue());
     }
 
     /**
      * Returns a composed function that first applies this function to
-     * its input, and then applies the {@code after} function to the result.
+     * its inputs, and then applies the {@code after} function to the result.
      * If evaluation of either function throws an exception, it is relayed to
      * the caller of the composed function.
      *
@@ -51,11 +64,109 @@ public interface ThrowableFunction2_0<X extends Throwable, T1, T2> extends Seria
      * applies the {@code after} function
      * @throws NullPointerException if after is null
      */
-    default ThrowableFunction2_0<X, T1, T2> andThen(ThrowableFunction0_0<X> after) {
+    default ThrowableFunction2_0<X, T1, T2> andRun(ThrowableFunction0_0<X> after) {
         Objects.requireNonNull(after);
-        return (T1 t1, T2 t2) -> {
+        return (t1, t2) -> {
             apply(t1, t2);
             after.apply();
         };
     }
+    /**
+     * Returns a composed function that first applies this function to
+     * its inputs, and then applies the {@code after} function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <V> the type of the result of the {@code after} function
+     * @param after the function to apply after this function is applied
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    default <V> ThrowableFunction2_1<X, T1, T2, V> andSupply(ThrowableFunction0_1<X, V> after) {
+        Objects.requireNonNull(after);
+        return (t1, t2) -> {
+            apply(t1, t2);
+            return after.apply();
+        };
+    }
+    /**
+     * Returns a composed function that first applies this function to
+     * its inputs, and then applies the {@code after} function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <V1> the type of key of the result entry
+     * @param <V2> the type of value of the result entry
+     * @param after the function to apply after this function is applied
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    default <V1, V2> ThrowableFunction2_2<X, T1, T2, V1, V2> andSupplyEntry(ThrowableFunction0_2<X, V1, V2> after) {
+        Objects.requireNonNull(after);
+        return (t1, t2) -> {
+            apply(t1, t2);
+            return after.apply();
+        };
+    }
+
+    /**
+     * Returns a composed function that first applies the {@code before} function to
+     * its input, and then applies this function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param before the function to apply before this function is applied
+     * @return a composed function that first applies the {@code before} function and
+     * then applies this function
+     * @throws NullPointerException if before is null
+     */
+    default ThrowableFunction0_0<X> compose(ThrowableFunction0_2<X, ? extends T1, ? extends T2> before) {
+        Objects.requireNonNull(before);
+        return () -> {
+            Tuple<? extends T1, ? extends T2> tuple = before.apply();
+            apply(tuple.t1(), tuple.t2());
+        };
+    }
+    /**
+     * Returns a composed function that first applies the {@code before} function to
+     * its input, and then applies this function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <I> type of parameter of before function
+     * @param before the function to apply before this function is applied
+     * @return a composed function that first applies the {@code before} function and
+     * then applies this function
+     * @throws NullPointerException if before is null
+     */
+    default <I> ThrowableFunction1_0<X, I> compose(ThrowableFunction1_2<X, ? super I, ? extends T1, ? extends T2> before) {
+        Objects.requireNonNull(before);
+        return t -> {
+            Tuple<? extends T1, ? extends T2> tuple = before.apply(t);
+            apply(tuple.t1(), tuple.t2());
+        };
+    }
+    /**
+     * Returns a composed function that first applies the {@code before} function to
+     * its input, and then applies this function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <I1> type of first parameter of before function
+     * @param <I2> type of second parameter of before function
+     * @param before the function to apply before this function is applied
+     * @return a composed function that first applies the {@code before} function and
+     * then applies this function
+     * @throws NullPointerException if before is null
+     */
+    default <I1, I2> ThrowableFunction2_0<X, I1, I2> compose(ThrowableFunction2_2<X, ? super I1, ? super I2, ? extends T1, ? extends T2> before) {
+        Objects.requireNonNull(before);
+        return (i1, i2) -> {
+            Tuple<? extends T1, ? extends T2> tuple = before.apply(i1, i2);
+            apply(tuple.t1(), tuple.t2());
+        };
+    }
+
 }

--- a/src/main/java/one/util/functionex/ThrowableFunction2_1.java
+++ b/src/main/java/one/util/functionex/ThrowableFunction2_1.java
@@ -1,0 +1,63 @@
+package one.util.functionex;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Represents a function with two arguments and returning one value.
+ *
+ * @param <X> the exception which may throw
+ * @param <T1> argument 1 of the function
+ * @param <T2> argument 2 of the function
+ * @param <R> return type 1 of the function
+ */
+
+@FunctionalInterface
+public interface ThrowableFunction2_1<X extends Throwable, T1, T2, R> extends Serializable {
+    /**
+     * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.
+     */
+    long serialVersionUID = 1L;
+
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param t1 the first function argument
+     * @param t2 the second function argument
+     * @return the function result
+     */
+    R apply(T1 t1, T2 t2) throws X;
+
+    /**
+     * Narrows the given {@code one.util.functionex.ThrowableFunction2_1<? extends Throwable, ? super T1, ? super T2, ? extends R>} to
+     * {@code one.util.functionex.ThrowableFunction2_1<? extends Throwable,T1,T2,R>}
+     *
+     * @param f A {@code one.util.functionex.ThrowableFunction2_1}
+     * @param <T1> The first parameter type
+     * @param <T2> The second parameter type
+     * @param <R> The return type
+     * @return the given {@code f} instance as narrowed type {@code one.util.functionex.ThrowableFunction2_1<? extends Throwable,T1,T2,R>}
+     */
+    @SuppressWarnings("unchecked")
+    static <T1, T2, R> ThrowableFunction2_1<? extends Throwable, T1, T2, R> narrow(ThrowableFunction2_1<? extends Throwable, ? super T1, ? super T2, ? extends R> f) {
+        return (ThrowableFunction2_1<? extends Throwable, T1, T2, R>) f;
+    }
+
+    /**
+     * Returns a composed function that first applies this function to
+     * its input, and then applies the {@code after} function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <V> the type of output of the {@code after} function, and of the
+     *           composed function
+     * @param after the function to apply after this function is applied
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    default <V> ThrowableFunction2_1<X, T1, T2, V> andThen(ThrowableFunction1_1<X, ? super R, ? extends V> after) {
+        Objects.requireNonNull(after);
+        return (T1 t1, T2 t2) -> after.apply(apply(t1, t2));
+    }
+}

--- a/src/main/java/one/util/functionex/ThrowableFunction2_1.java
+++ b/src/main/java/one/util/functionex/ThrowableFunction2_1.java
@@ -1,6 +1,7 @@
 package one.util.functionex;
 
 import java.io.Serializable;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -25,6 +26,7 @@ public interface ThrowableFunction2_1<X extends Throwable, T1, T2, R> extends Se
      * @param t1 the first function argument
      * @param t2 the second function argument
      * @return the function result
+     * @throws X Exception that function may throw
      */
     R apply(T1 t1, T2 t2) throws X;
 
@@ -33,14 +35,26 @@ public interface ThrowableFunction2_1<X extends Throwable, T1, T2, R> extends Se
      * {@code one.util.functionex.ThrowableFunction2_1<? extends Throwable,T1,T2,R>}
      *
      * @param f A {@code one.util.functionex.ThrowableFunction2_1}
+     * @param <X>  Exception that f may declare to throw
      * @param <T1> The first parameter type
      * @param <T2> The second parameter type
      * @param <R> The return type
      * @return the given {@code f} instance as narrowed type {@code one.util.functionex.ThrowableFunction2_1<? extends Throwable,T1,T2,R>}
      */
     @SuppressWarnings("unchecked")
-    static <T1, T2, R> ThrowableFunction2_1<? extends Throwable, T1, T2, R> narrow(ThrowableFunction2_1<? extends Throwable, ? super T1, ? super T2, ? extends R> f) {
-        return (ThrowableFunction2_1<? extends Throwable, T1, T2, R>) f;
+    static <X extends Throwable, T1, T2, R> ThrowableFunction2_1<X, T1, T2, R> narrow(ThrowableFunction2_1<X, ? super T1, ? super T2, ? extends R> f) {
+        return (ThrowableFunction2_1<X, T1, T2, R>) f;
+    }
+
+    /**
+     * Applies this function to the given arguments wrapped in a Tuple of 2 values.
+     *
+     * @param value tuple of 2 function argument
+     * @return the function result
+     * @throws X Exception that function may throw
+     */
+    default R apply(Map.Entry<T1, T2> value) throws X {
+        return apply(value.getKey(), value.getValue());
     }
 
     /**
@@ -49,15 +63,106 @@ public interface ThrowableFunction2_1<X extends Throwable, T1, T2, R> extends Se
      * If evaluation of either function throws an exception, it is relayed to
      * the caller of the composed function.
      *
-     * @param <V> the type of output of the {@code after} function, and of the
-     *           composed function
      * @param after the function to apply after this function is applied
      * @return a composed function that first applies this function and then
      * applies the {@code after} function
      * @throws NullPointerException if after is null
      */
-    default <V> ThrowableFunction2_1<X, T1, T2, V> andThen(ThrowableFunction1_1<X, ? super R, ? extends V> after) {
+    default ThrowableFunction2_0<X, T1, T2> andConsume(ThrowableFunction1_0<X, ? super R> after) {
         Objects.requireNonNull(after);
-        return (T1 t1, T2 t2) -> after.apply(apply(t1, t2));
+        return (t1, t2) -> after.apply(apply(t1, t2));
     }
+    /**
+     * Returns a composed function that first applies this function to
+     * its input, and then applies the {@code after} function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <V> the type of the result of the {@code after} function
+     * @param after the function to apply after this function is applied
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    default <V> ThrowableFunction2_1<X, T1, T2, V> andMap(ThrowableFunction1_1<X, ? super R, ? extends V> after) {
+        Objects.requireNonNull(after);
+        return (t1, t2) -> after.apply(apply(t1, t2));
+    }
+    /**
+     * Returns a composed function that first applies this function to
+     * its input, and then applies the {@code after} function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <V1> the type of key of the result entry
+     * @param <V2> the type of value of the result entry
+     * @param after the function to apply after this function is applied
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    @SuppressWarnings("unchecked")
+    default <V1, V2> ThrowableFunction2_2<X, T1, T2, V1, V2> andMapToEntry(ThrowableFunction1_2<X, ? super R, ? extends V1, ? extends V2> after) {
+        Objects.requireNonNull(after);
+        return (t1, t2) -> (Tuple<V1, V2>) after.apply(apply(t1, t2));
+    }
+
+    /**
+     * Returns a composed function that first applies the {@code before} function to
+     * its input, and then applies this function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param before the function to apply before this function is applied
+     * @return a composed function that first applies the {@code before} function and
+     * then applies this function
+     * @throws NullPointerException if before is null
+     */
+    default ThrowableFunction0_1<X, R> compose(ThrowableFunction0_2<X, ? extends T1, ? extends T2> before) {
+        Objects.requireNonNull(before);
+        return () -> {
+            Tuple<? extends T1, ? extends T2> tuple = before.apply();
+            return apply(tuple.t1(), tuple.t2());
+        };
+    }
+    /**
+     * Returns a composed function that first applies the {@code before} function to
+     * its input, and then applies this function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <I> type of parameter of before function
+     * @param before the function to apply before this function is applied
+     * @return a composed function that first applies the {@code before} function and
+     * then applies this function
+     * @throws NullPointerException if before is null
+     */
+    default <I> ThrowableFunction1_1<X, I, R> compose(ThrowableFunction1_2<X, ? super I, ? extends T1, ? extends T2> before) {
+        Objects.requireNonNull(before);
+        return i1 -> {
+            Tuple<? extends T1, ? extends T2> tuple = before.apply(i1);
+            return apply(tuple.t1(), tuple.t2());
+        };
+    }
+    /**
+     * Returns a composed function that first applies the {@code before} function to
+     * its input, and then applies this function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <I1> type of first parameter of before function
+     * @param <I2> type of second parameter of before function
+     * @param before the function to apply before this function is applied
+     * @return a composed function that first applies the {@code before} function and
+     * then applies this function
+     * @throws NullPointerException if before is null
+     */
+    default <I1, I2> ThrowableFunction2_1<X, I1, I2, R> compose(ThrowableFunction2_2<X, ? super I1, ? super I2, ? extends T1, ? extends T2> before) {
+        Objects.requireNonNull(before);
+        return (i1, i2) -> {
+            Tuple<? extends T1, ? extends T2> tuple = before.apply(i1, i2);
+            return apply(tuple.t1(), tuple.t2());
+        };
+    }
+
 }

--- a/src/main/java/one/util/functionex/ThrowableFunction2_2.java
+++ b/src/main/java/one/util/functionex/ThrowableFunction2_2.java
@@ -26,9 +26,10 @@ public interface ThrowableFunction2_2<X extends Throwable, T1, T2, R1, R2> exten
      *
      * @param t1 the first function argument
      * @param t2 the second function argument
-     * @return a @{@link Map.Entry} of 2 values
+     * @return a @{@link Tuple} of 2 values
+     * @throws X Exception that function may throw
      */
-    Map.Entry<R1, R2> apply(T1 t1, T2 t2) throws X;
+    Tuple<R1, R2> apply(T1 t1, T2 t2) throws X;
 
 
     /**
@@ -36,6 +37,7 @@ public interface ThrowableFunction2_2<X extends Throwable, T1, T2, R1, R2> exten
      * {@code one.util.functionex.ThrowableFunction2_2<? extends Throwable,T1,T2,R1,R2>}
      *
      * @param f A {@code one.util.functionex.ThrowableFunction2_2}
+     * @param <X>  Exception that f may declare to throw
      * @param <T1> The first parameter type
      * @param <T2> The second parameter type
      * @param <R1> The first return type
@@ -43,17 +45,18 @@ public interface ThrowableFunction2_2<X extends Throwable, T1, T2, R1, R2> exten
      * @return the given {@code f} instance as narrowed type {@code one.util.functionex.ThrowableFunction2_2<? extends Throwable,T1,T2,R1,R2>}
      */
     @SuppressWarnings("unchecked")
-    static <T1, T2, R1, R2> ThrowableFunction2_2<? extends Throwable, T1, T2, R1, R2> narrow(ThrowableFunction2_2<? extends Throwable, ? super T1, ? super T2, ? extends R1, ? extends R2> f) {
-        return (ThrowableFunction2_2<? extends Throwable, T1, T2, R1, R2>) f;
+    static <X extends Throwable, T1, T2, R1, R2> ThrowableFunction2_2<X, T1, T2, R1, R2> narrow(ThrowableFunction2_2<X, ? super T1, ? super T2, ? extends R1, ? extends R2> f) {
+        return (ThrowableFunction2_2<X, T1, T2, R1, R2>) f;
     }
 
     /**
      * Applies this function to the given arguments wrapped in a Tuple of 2 values.
      *
      * @param value tuple of 2 function argument
-     * @return a @{@link Map.Entry} of 2 values
+     * @return a @{@link Tuple} of 2 values
+     * @throws X Exception that function may throw
      */
-    default Map.Entry<R1, R2> apply(Map.Entry<T1, T2> value) throws X {
+    default Tuple<R1, R2> apply(Map.Entry<T1, T2> value) throws X {
         return apply(value.getKey(), value.getValue());
     }
 
@@ -63,21 +66,114 @@ public interface ThrowableFunction2_2<X extends Throwable, T1, T2, R1, R2> exten
      * If evaluation of either function throws an exception, it is relayed to
      * the caller of the composed function.
      *
-     * @param <V1> the type of the first output of the {@code after} function
-     * @param <V2> the type of the second output of the {@code after} function
+     * @param after the function to apply after this function is applied
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    default ThrowableFunction2_0<X, T1, T2> andConsume(ThrowableFunction2_0<X, ? super R1, ? super R2> after) {
+        Objects.requireNonNull(after);
+        return (t1, t2) -> {
+            Tuple<R1, R2> tuple = apply(t1, t2);
+            after.apply(tuple.t1(), tuple.t2());
+        };
+    }
+    /**
+     * Returns a composed function that first applies this function to
+     * its input, and then applies the {@code after} function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
      *
+     * @param <V> the type of the result of the {@code after} function
+     * @param after the function to apply after this function is applied
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    default <V> ThrowableFunction2_1<X, T1, T2, V> andReduce(ThrowableFunction2_1<X, ? super R1, ? super R2, ? extends V> after) {
+        Objects.requireNonNull(after);
+        return (t1, t2) -> {
+            Tuple<R1, R2> tuple = apply(t1, t2);
+            return after.apply(tuple.t1(), tuple.t2());
+        };
+    }
+    /**
+     * Returns a composed function that first applies this function to
+     * its input, and then applies the {@code after} function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <V1> the type of key of the result entry
+     * @param <V2> the type of value of the result entry
      * @param after the function to apply after this function is applied
      * @return a composed function that first applies this function and then
      * applies the {@code after} function
      * @throws NullPointerException if after is null
      */
     @SuppressWarnings("unchecked")
-    default <V1, V2> ThrowableFunction2_2<X, T1, T2, V1, V2> andThen(ThrowableFunction2_2<X, ? super R1, ? super R2, ? extends V1, ? extends V2> after) {
+    default <V1, V2> ThrowableFunction2_2<X, T1, T2, V1, V2> andMap(ThrowableFunction2_2<X, ? super R1, ? super R2, ? extends V1, ? extends V2> after) {
         Objects.requireNonNull(after);
-        return (T1 t1, T2 t2) -> {
-            Map.Entry<R1, R2> value = apply(t1, t2);
-            return (Map.Entry<V1, V2>) after.apply(value.getKey(), value.getValue());
+        return (t1, t2) -> {
+            Tuple<R1, R2> tuple = apply(t1, t2);
+            return (Tuple<V1, V2>) after.apply(tuple.t1(), tuple.t2());
         };
     }
 
+    /**
+     * Returns a composed function that first applies the {@code before} function to
+     * its input, and then applies this function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param before the function to apply before this function is applied
+     * @return a composed function that first applies the {@code before} function and
+     * then applies this function
+     * @throws NullPointerException if before is null
+     */
+    default ThrowableFunction0_2<X, R1, R2> compose(ThrowableFunction0_2<X, ? extends T1, ? extends T2> before) {
+        Objects.requireNonNull(before);
+        return () -> {
+            Tuple<? extends T1, ? extends T2> tuple = before.apply();
+            return apply(tuple.t1(), tuple.t2());
+        };
+    }
+    /**
+     * Returns a composed function that first applies the {@code before} function to
+     * its input, and then applies this function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <I> type of parameter of before function
+     * @param before the function to apply before this function is applied
+     * @return a composed function that first applies the {@code before} function and
+     * then applies this function
+     * @throws NullPointerException if before is null
+     */
+    default <I> ThrowableFunction1_2<X, I, R1, R2> compose(ThrowableFunction1_2<X, ? super I, ? extends T1, ? extends T2> before) {
+        Objects.requireNonNull(before);
+        return i1 -> {
+            Tuple<? extends T1, ? extends T2> tuple = before.apply(i1);
+            return apply(tuple.t1(), tuple.t2());
+        };
+    }
+    /**
+     * Returns a composed function that first applies the {@code before} function to
+     * its input, and then applies this function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <I1> type of first parameter of before function
+     * @param <I2> type of second parameter of before function
+     * @param before the function to apply before this function is applied
+     * @return a composed function that first applies the {@code before} function and
+     * then applies this function
+     * @throws NullPointerException if before is null
+     */
+    default <I1, I2> ThrowableFunction2_2<X, I1, I2, R1, R2> compose(ThrowableFunction2_2<X, ? super I1, ? super I2, ? extends T1, ? extends T2> before) {
+        Objects.requireNonNull(before);
+        return (i1, i2) -> {
+            Tuple<? extends T1, ? extends T2> tuple = before.apply(i1, i2);
+            return apply(tuple.t1(), tuple.t2());
+        };
+    }
 }

--- a/src/main/java/one/util/functionex/ThrowableFunction2_2.java
+++ b/src/main/java/one/util/functionex/ThrowableFunction2_2.java
@@ -1,0 +1,83 @@
+package one.util.functionex;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents a function with two arguments and returning two values.
+ *
+ * @param <X> the exception which may throw
+ * @param <T1> argument 1 of the function
+ * @param <T2> argument 2 of the function
+ * @param <R1> return type 1 of the function
+ * @param <R2> return type 2 of the function
+ */
+
+@FunctionalInterface
+public interface ThrowableFunction2_2<X extends Throwable, T1, T2, R1, R2> extends Serializable {
+    /**
+     * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.
+     */
+    long serialVersionUID = 1L;
+
+    /**
+     * Applies this function to the given arguments and returns a Tuple of 2 values.
+     *
+     * @param t1 the first function argument
+     * @param t2 the second function argument
+     * @return a @{@link Map.Entry} of 2 values
+     */
+    Map.Entry<R1, R2> apply(T1 t1, T2 t2) throws X;
+
+
+    /**
+     * Narrows the given {@code one.util.functionex.ThrowableFunction2_2<? extends Throwable, ? super T1, ? super T2, ? extends R1, ? extends R2>} to
+     * {@code one.util.functionex.ThrowableFunction2_2<? extends Throwable,T1,T2,R1,R2>}
+     *
+     * @param f A {@code one.util.functionex.ThrowableFunction2_2}
+     * @param <T1> The first parameter type
+     * @param <T2> The second parameter type
+     * @param <R1> The first return type
+     * @param <R2> The second return type
+     * @return the given {@code f} instance as narrowed type {@code one.util.functionex.ThrowableFunction2_2<? extends Throwable,T1,T2,R1,R2>}
+     */
+    @SuppressWarnings("unchecked")
+    static <T1, T2, R1, R2> ThrowableFunction2_2<? extends Throwable, T1, T2, R1, R2> narrow(ThrowableFunction2_2<? extends Throwable, ? super T1, ? super T2, ? extends R1, ? extends R2> f) {
+        return (ThrowableFunction2_2<? extends Throwable, T1, T2, R1, R2>) f;
+    }
+
+    /**
+     * Applies this function to the given arguments wrapped in a Tuple of 2 values.
+     *
+     * @param value tuple of 2 function argument
+     * @return a @{@link Map.Entry} of 2 values
+     */
+    default Map.Entry<R1, R2> apply(Map.Entry<T1, T2> value) throws X {
+        return apply(value.getKey(), value.getValue());
+    }
+
+    /**
+     * Returns a composed function that first applies this function to
+     * its input, and then applies the {@code after} function to the result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param <V1> the type of the first output of the {@code after} function
+     * @param <V2> the type of the second output of the {@code after} function
+     *
+     * @param after the function to apply after this function is applied
+     * @return a composed function that first applies this function and then
+     * applies the {@code after} function
+     * @throws NullPointerException if after is null
+     */
+    @SuppressWarnings("unchecked")
+    default <V1, V2> ThrowableFunction2_2<X, T1, T2, V1, V2> andThen(ThrowableFunction2_2<X, ? super R1, ? super R2, ? extends V1, ? extends V2> after) {
+        Objects.requireNonNull(after);
+        return (T1 t1, T2 t2) -> {
+            Map.Entry<R1, R2> value = apply(t1, t2);
+            return (Map.Entry<V1, V2>) after.apply(value.getKey(), value.getValue());
+        };
+    }
+
+}

--- a/src/main/java/one/util/functionex/ThrowablePredicate1.java
+++ b/src/main/java/one/util/functionex/ThrowablePredicate1.java
@@ -31,12 +31,13 @@ public interface ThrowablePredicate1<X extends Throwable, T> extends Serializabl
      * {@code one.util.functionex.ThrowablePredicate1<? extends Throwable,T>}
      *
      * @param f A {@code one.util.functionex.ThrowablePredicate1}
+     * @param <X>  Exception that f may declare to throw
      * @param <T> The parameter type
      * @return the given {@code f} instance as narrowed type {@code one.util.functionex.ThrowablePredicate1<? extends Throwable,T>}
      */
     @SuppressWarnings("unchecked")
-    static <T> ThrowablePredicate1<? extends Throwable, T> narrow(ThrowablePredicate1<? extends Throwable, ? super T> f) {
-        return (ThrowablePredicate1<? extends Throwable, T>) f;
+    static <X extends Throwable, T> ThrowablePredicate1<X, T> narrow(ThrowablePredicate1<X, ? super T> f) {
+        return (ThrowablePredicate1<X, T>) f;
     }
 
     /**

--- a/src/main/java/one/util/functionex/ThrowablePredicate1.java
+++ b/src/main/java/one/util/functionex/ThrowablePredicate1.java
@@ -1,0 +1,134 @@
+package one.util.functionex;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * A {@linkplain java.util.function.Predicate} which may throw taking one argument.
+ *
+ * @param <X> the exception which may throw
+ * @param <T> the type of the input to the predicate
+ */
+@FunctionalInterface
+public interface ThrowablePredicate1<X extends Throwable, T> extends Serializable {
+    /**
+     * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.
+     */
+    long serialVersionUID = 1L;
+
+    /**
+     * Evaluates this predicate on the given argument.
+     *
+     * @param t the input argument
+     * @return {@code true} if the input argument matches the predicate,
+     * otherwise {@code false}
+     * @throws X if an exception occured
+     */
+    boolean test(T t) throws X;
+
+    /**
+     * Narrows the given {@code one.util.functionex.ThrowablePredicate1<? extends Throwable, ? super T>} to
+     * {@code one.util.functionex.ThrowablePredicate1<? extends Throwable,T>}
+     *
+     * @param f A {@code one.util.functionex.ThrowablePredicate1}
+     * @param <T> The parameter type
+     * @return the given {@code f} instance as narrowed type {@code one.util.functionex.ThrowablePredicate1<? extends Throwable,T>}
+     */
+    @SuppressWarnings("unchecked")
+    static <T> ThrowablePredicate1<? extends Throwable, T> narrow(ThrowablePredicate1<? extends Throwable, ? super T> f) {
+        return (ThrowablePredicate1<? extends Throwable, T>) f;
+    }
+
+    /**
+     * Returns a composed predicate that represents a short-circuiting logical
+     * AND of this predicate and another.  When evaluating the composed
+     * predicate, if this predicate is {@code false}, then the {@code other}
+     * predicate is not evaluated.
+     *
+     * <p>Any exceptions thrown during evaluation of either predicate are relayed
+     * to the caller; if evaluation of this predicate throws an exception, the
+     * {@code other} predicate will not be evaluated.
+     *
+     * @param other a predicate that will be logically-ANDed with this
+     *              predicate
+     * @return a composed predicate that represents the short-circuiting logical
+     * AND of this predicate and the {@code other} predicate
+     * @throws NullPointerException if other is null
+     */
+    default ThrowablePredicate1<X, T> and(ThrowablePredicate1<X, ? super T> other) {
+        Objects.requireNonNull(other);
+        return (t) -> test(t) && other.test(t);
+    }
+
+    /**
+     * Returns a predicate that represents the logical negation of this
+     * predicate.
+     *
+     * @return a predicate that represents the logical negation of this
+     * predicate
+     */
+    default ThrowablePredicate1<X, T> negate() {
+        return (t) -> !test(t);
+    }
+
+    /**
+     * Returns a composed predicate that represents a short-circuiting logical
+     * OR of this predicate and another.  When evaluating the composed
+     * predicate, if this predicate is {@code true}, then the {@code other}
+     * predicate is not evaluated.
+     *
+     * <p>Any exceptions thrown during evaluation of either predicate are relayed
+     * to the caller; if evaluation of this predicate throws an exception, the
+     * {@code other} predicate will not be evaluated.
+     *
+     * @param other a predicate that will be logically-ORed with this
+     *              predicate
+     * @return a composed predicate that represents the short-circuiting logical
+     * OR of this predicate and the {@code other} predicate
+     * @throws NullPointerException if other is null
+     */
+    default ThrowablePredicate1<X, T> or(ThrowablePredicate1<X, ? super T> other) {
+        Objects.requireNonNull(other);
+        return (t) -> test(t) || other.test(t);
+    }
+
+    /**
+     * Returns a predicate that tests if two arguments are equal according
+     * to {@link Objects#equals(Object, Object)}.
+     *
+     * @param <X>     the type of exception the test can throw
+     * @param <T> the type of arguments to the predicate
+     * @param targetRef the object reference with which to compare for equality,
+     *               which may be {@code null}
+     * @return a predicate that tests if two arguments are equal according
+     * to {@link Objects#equals(Object, Object)}
+     */
+    static <X extends Throwable, T> ThrowablePredicate1<X, T> isEqual(Object targetRef) {
+        return (null == targetRef)
+            ? Objects::isNull
+            : targetRef::equals;
+    }
+
+    /**
+     * Returns a predicate that is the negation of the supplied predicate.
+     * This is accomplished by returning result of the calling
+     * {@code target.negate()}.
+     *
+     * @param <X>     the type of exception the test can throw
+     * @param <T>     the type of arguments to the specified predicate
+     * @param target  predicate to negate
+     *
+     * @return a predicate that negates the results of the supplied
+     *         predicate
+     *
+     * @throws NullPointerException if target is null
+     *
+     * @since 11
+     */
+    @SuppressWarnings("unchecked")
+    static <X extends Throwable, T> ThrowablePredicate1<X, T> not(ThrowablePredicate1<X, ? super T> target) {
+        Objects.requireNonNull(target);
+        return (ThrowablePredicate1<X, T>)target.negate();
+    }
+
+}

--- a/src/main/java/one/util/functionex/ThrowablePredicate2.java
+++ b/src/main/java/one/util/functionex/ThrowablePredicate2.java
@@ -1,0 +1,140 @@
+package one.util.functionex;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * A {@linkplain java.util.function.Predicate} which may throw taking two arguments.
+ *
+ * @param <X> the exception which may throw
+ * @param <T1> the type of the first input to the predicate
+ * @param <T2> the type of the second input to the predicate
+ */
+@FunctionalInterface
+public interface ThrowablePredicate2<X extends Throwable, T1, T2> extends Serializable {
+    /**
+     * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.
+     */
+    long serialVersionUID = 1L;
+
+    /**
+     * Evaluates this predicate on the given argument.
+     *
+     * @param t1 the first input argument
+     * @param t2 the second input argument
+     * @return {@code true} if the input argument matches the predicate,
+     * otherwise {@code false}
+     * @throws X if an exception occured
+     */
+    boolean test(T1 t1, T2 t2) throws X;
+
+    /**
+     * Narrows the given {@code one.util.functionex.ThrowablePredicate2<? extends Throwable, ? super T1, ? super T2>} to
+     * {@code one.util.functionex.ThrowablePredicate2<? extends Throwable,T1,T2>}
+     *
+     * @param f A {@code one.util.functionex.ThrowablePredicate2}
+     * @param <T1> The first parameter type
+     * @param <T2> The second parameter type
+     * @return the given {@code f} instance as narrowed type {@code one.util.functionex.ThrowablePredicate2<? extends Throwable,T1,T2>}
+     */
+    @SuppressWarnings("unchecked")
+    static <T1, T2> ThrowablePredicate2<? extends Throwable, T1, T2> narrow(ThrowablePredicate2<? extends Throwable, ? super T1, ? super T2> f) {
+        return (ThrowablePredicate2<? extends Throwable, T1, T2>) f;
+    }
+
+    /**
+     * Returns a composed predicate that represents a short-circuiting logical
+     * AND of this predicate and another.  When evaluating the composed
+     * predicate, if this predicate is {@code false}, then the {@code other}
+     * predicate is not evaluated.
+     *
+     * <p>Any exceptions thrown during evaluation of either predicate are relayed
+     * to the caller; if evaluation of this predicate throws an exception, the
+     * {@code other} predicate will not be evaluated.
+     *
+     * @param other a predicate that will be logically-ANDed with this
+     *              predicate
+     * @return a composed predicate that represents the short-circuiting logical
+     * AND of this predicate and the {@code other} predicate
+     * @throws NullPointerException if other is null
+     */
+    default ThrowablePredicate2<X, T1, T2> and(ThrowablePredicate2<X, ? super T1, ? super T2> other) {
+        Objects.requireNonNull(other);
+        return (t1, t2) -> test(t1, t2) && other.test(t1, t2);
+    }
+
+    /**
+     * Returns a predicate that represents the logical negation of this
+     * predicate.
+     *
+     * @return a predicate that represents the logical negation of this
+     * predicate
+     */
+    default ThrowablePredicate2<X, T1, T2> negate() {
+        return (t1, t2) -> !test(t1, t2);
+    }
+
+    /**
+     * Returns a composed predicate that represents a short-circuiting logical
+     * OR of this predicate and another.  When evaluating the composed
+     * predicate, if this predicate is {@code true}, then the {@code other}
+     * predicate is not evaluated.
+     *
+     * <p>Any exceptions thrown during evaluation of either predicate are relayed
+     * to the caller; if evaluation of this predicate throws an exception, the
+     * {@code other} predicate will not be evaluated.
+     *
+     * @param other a predicate that will be logically-ORed with this
+     *              predicate
+     * @return a composed predicate that represents the short-circuiting logical
+     * OR of this predicate and the {@code other} predicate
+     * @throws NullPointerException if other is null
+     */
+    default ThrowablePredicate2<X, T1, T2> or(ThrowablePredicate2<X, ? super T1, ? super T2> other) {
+        Objects.requireNonNull(other);
+        return (t1, t2) -> test(t1, t2) || other.test(t1, t2);
+    }
+
+    /**
+     * Returns a predicate that tests if two arguments are equal according
+     * to {@link Objects#equals(Object, Object)}.
+     *
+     * @param <X>     the type of exception the test can throw
+     * @param <T1>    the type of the first argument to the specified predicate
+     * @param <T2>    the type of the second argument to the specified predicate
+     * @param targetRef1 the object reference with which to compare for equality with the first parameter,
+     * @param targetRef2 the object reference with which to compare for equality with the second parameter,
+     *               which may be {@code null}
+     * @return a predicate that tests if two arguments are equal according
+     * to {@link Objects#equals(Object, Object)}
+     */
+    static <X extends Throwable, T1, T2> ThrowablePredicate2<X, T1, T2> isEqual(Object targetRef1, Object targetRef2) {
+        return (t1, t2) ->
+            ((null == targetRef1) ? Objects.isNull(t1) : targetRef1.equals(t1)) &&
+            ((null == targetRef2) ? Objects.isNull(t2) : targetRef2.equals(t2));
+    }
+
+    /**
+     * Returns a predicate that is the negation of the supplied predicate.
+     * This is accomplished by returning result of the calling
+     * {@code target.negate()}.
+     *
+     * @param <X>     the type of exception the test can throw
+     * @param <T1>    the type of the first argument to the specified predicate
+     * @param <T2>    the type of the second argument to the specified predicate
+     * @param target  predicate to negate
+     *
+     * @return a predicate that negates the results of the supplied
+     *         predicate
+     *
+     * @throws NullPointerException if target is null
+     *
+     * @since 11
+     */
+    @SuppressWarnings("unchecked")
+    static <X extends Throwable, T1, T2> ThrowablePredicate2<X, T1, T2> not(ThrowablePredicate2<X, ? super T1, ? super T2> target) {
+        Objects.requireNonNull(target);
+        return (ThrowablePredicate2<X, T1, T2>)target.negate();
+    }
+
+}

--- a/src/main/java/one/util/functionex/ThrowablePredicate2.java
+++ b/src/main/java/one/util/functionex/ThrowablePredicate2.java
@@ -29,17 +29,30 @@ public interface ThrowablePredicate2<X extends Throwable, T1, T2> extends Serial
     boolean test(T1 t1, T2 t2) throws X;
 
     /**
+     * Evaluates this predicate on the given argument.
+     *
+     * @param tuple tuple of 2 function argument
+     * @return {@code true} if the input argument matches the predicate,
+     * otherwise {@code false}
+     * @throws X if an exception occured
+     */
+    default boolean test(Tuple<T1, T2> tuple) throws X {
+        return test(tuple.t1(), tuple.t2());
+    }
+
+    /**
      * Narrows the given {@code one.util.functionex.ThrowablePredicate2<? extends Throwable, ? super T1, ? super T2>} to
      * {@code one.util.functionex.ThrowablePredicate2<? extends Throwable,T1,T2>}
      *
      * @param f A {@code one.util.functionex.ThrowablePredicate2}
+     * @param <X>  Exception that f may declare to throw
      * @param <T1> The first parameter type
      * @param <T2> The second parameter type
      * @return the given {@code f} instance as narrowed type {@code one.util.functionex.ThrowablePredicate2<? extends Throwable,T1,T2>}
      */
     @SuppressWarnings("unchecked")
-    static <T1, T2> ThrowablePredicate2<? extends Throwable, T1, T2> narrow(ThrowablePredicate2<? extends Throwable, ? super T1, ? super T2> f) {
-        return (ThrowablePredicate2<? extends Throwable, T1, T2>) f;
+    static <X extends Throwable, T1, T2> ThrowablePredicate2<X, T1, T2> narrow(ThrowablePredicate2<X, ? super T1, ? super T2> f) {
+        return (ThrowablePredicate2<X, T1, T2>) f;
     }
 
     /**

--- a/src/main/java/one/util/functionex/Tuple.java
+++ b/src/main/java/one/util/functionex/Tuple.java
@@ -1,0 +1,100 @@
+package one.util.functionex;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * An object that contains 2 elements of any type
+ * <br/>
+ * This object can be used as an {@link Map.Entry} where :
+ * <ul>
+ *  <li>the type T1 is the key</li>
+ *  <li>the type T2 is the value</li>
+ * </ul>
+ * @param <T1> type of the first element, type of key when used as an {@link Map.Entry}
+ * @param <T2> type of the second element, type of value when used as an {@link Map.Entry}
+ */
+public class Tuple<T1, T2> implements Map.Entry<T1, T2> {
+    private final T1 t1;
+    private final T2 t2;
+
+    /**
+     * constructs a new Tuple
+     * @param t1 first element of type T1
+     * @param t2 second element of type T2
+     */
+    public Tuple(T1 t1, T2 t2) {
+        this.t1 = t1;
+        this.t2 = t2;
+    }
+
+    /**
+     * constructs a new Tuple
+     * @param <T1> Type of first element
+     * @param <T2> Type of second element
+     * @param t1 first element of type T1
+     * @param t2 second element of type T2
+     * @return a new Tuple
+     */
+    public static <T1, T2> Tuple<T1, T2> of(T1 t1, T2 t2) {
+        return new Tuple<>(t1, t2);
+    }
+
+    @Override
+    public String toString() {
+        return "Tuple{" +
+            "t1=" + t1 +
+            ", t2=" + t2 +
+            '}';
+    }
+
+    /**
+     * Get first element of the tuple
+     * @return the first element
+     */
+    public T1 t1() {
+        return t1;
+    }
+
+    /**
+     * Get second element of the tuple
+     * @return the second element
+     */
+    public T2 t2() {
+        return t2;
+    }
+
+    @Override
+    public T1 getKey() {
+        return t1;
+    }
+
+    @Override
+    public T2 getValue() {
+        return t2;
+    }
+
+    @Override
+    public T2 setValue(T2 value) {
+        throw new UnsupportedOperationException("Tuple is immutable");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Tuple<?, ?> tuple = (Tuple<?, ?>) o;
+
+        if (!Objects.equals(t1, tuple.t1)) return false;
+        return Objects.equals(t2, tuple.t2);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = t1 != null ? t1.hashCode() : 0;
+        result = 31 * result + (t2 != null ? t2.hashCode() : 0);
+        return result;
+    }
+
+}

--- a/src/main/java/one/util/functionex/package-info.java
+++ b/src/main/java/one/util/functionex/package-info.java
@@ -1,0 +1,17 @@
+/**
+ * This packaqe contains all throwable function interface needed in StreamEx.
+ * The goal is to externalize this package in another module to be able to use it with
+ * another library that I would like to propose after this.
+ * <br/>
+ * Maybe, the convention of class names won't be accepted, but it is not a problem for me to
+ * adapt names like
+ *  - {@link one.util.functionex.ThrowableFunction0_1} to {@code ThrowableSupplier}
+ *  - {@link one.util.functionex.ThrowableFunction0_2} to {@code ThrowableBiSupplier} or {@code ThrowableEntrySupplier}
+ *  - {@link one.util.functionex.ThrowableFunction1_0} to {@code ThrowableConsumer}
+ *  - {@link one.util.functionex.ThrowableFunction1_1} to {@code ThrowableFunction}
+ *  - {@link one.util.functionex.ThrowableFunction2_2} to {@code ThrowableBiToBiFunction} or {@code ThrowableBiToEntryFunction}for example
+ *  - {@link one.util.functionex.ThrowableFunction1_2} to {@code ThrowableToBiFunction} for example
+ *  - ...
+ */
+package one.util.functionex;
+

--- a/src/main/java/one/util/streamex/AbstractStreamEx.java
+++ b/src/main/java/one/util/streamex/AbstractStreamEx.java
@@ -206,14 +206,19 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #filter(Predicate)} but accepts Throwable Functions instead and declares exception
      * may mapper function throw
+     *
      * @param <X> Exception Type the mapper function may throw
+     * @param predicate predicate to apply to each element to determine if it should be included
      * @throws X Exception that mapper function may throw
+     * @return the new stream
      */
     public <X extends Throwable> S filterThrowing(ThrowablePredicate1<X, ? super T> predicate) throws X {
         return tryFilter(predicate);
     }
     /**
      * Equivalent to {@link #filterThrowing(ThrowablePredicate1)} but hides the exception that mapper function may throw
+     * @param predicate predicate to apply to each element to determine if it should be included
+     * @return the new stream
      */
     public S tryFilter(ThrowablePredicate1<? extends Throwable, ? super T> predicate) {
         return filter(toPredicateSneakyThrowing(predicate));
@@ -227,7 +232,10 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
      * Equivalent to {@link #flatMap(Function)} but accepts Throwable Functions instead and declares exception
      * may mapper function throw
      *
+     * @param <R> The element type of the new stream
      * @param <X> Exception Type the mapper function may throw
+     * @param mapper function to apply to each element which produces a stream of new values
+     * @return the new stream
      * @throws X Exception that mapper function may throw
      */
     public <X extends Throwable, R> StreamEx<R> flatMapThrowing(ThrowableFunction1_1<X, ? super T, ? extends Stream<? extends R>> mapper) throws X {
@@ -235,6 +243,9 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     }
     /**
      * Equivalent to {@link #flatMapThrowing(ThrowableFunction1_1)} but hides the exception that mapper function may throw
+     * @param <R> The element type of the new stream
+     * @param mapper function to apply to each element which produces a stream of new values
+     * @return the new stream
      */
     public <R> StreamEx<R> tryFlatMap(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends Stream<? extends R>> mapper) {
         return flatMap(toFunctionSneakyThrowing(mapper));
@@ -262,7 +273,13 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #mapMulti(BiConsumer)} but accepts Throwable Functions instead and declares exception
      * may mapper function throw
+     *
+     * @param mapper a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *               <a href="package-summary.html#Statelessness">stateless</a>
+     *               function that generates replacement elements. It accepts an element of this
+     *               stream and a consumer that accepts new elements produced from the input element.
      * @return the new stream
+     * @param <R> The element type of the new stream
      * @param <X> Exception Type the mapper function may throw
      * @throws X Exception that mapper function may throw
      */
@@ -271,6 +288,12 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     }
     /**
      * Equivalent to {@link #mapMultiThrowing(ThrowableFunction2_0)} but hides the exception that mapper function may throw
+     * @param <R> The element type of the new stream
+     * @param mapper a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *               <a href="package-summary.html#Statelessness">stateless</a>
+     *               function that generates replacement elements. It accepts an element of this
+     *               stream and a consumer that accepts new elements produced from the input element.
+     * @return the new stream
      */
     public <R> StreamEx<R> tryMapMulti(ThrowableFunction2_0<? extends Throwable, ? super T, ? super Consumer<R>> mapper) {
         Objects.requireNonNull(mapper);
@@ -298,6 +321,11 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #mapMultiToInt(BiConsumer)} but accepts Throwable Functions instead and declares exception
      * may mapper function throw
+     * @param mapper a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *               <a href="package-summary.html#Statelessness">stateless</a>
+     *               function that generates replacement elements. It accepts an element of this
+     *               stream and a consumer that accepts new elements produced from the input element.
+     * @return the new stream
      * @param <X> Exception Type the mapper function may throw
      * @throws X Exception that mapper function may throw
      */
@@ -306,6 +334,11 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     }
     /**
      * Equivalent to {@link #mapMultiToIntThrowing(ThrowableFunction2_0)} but hides the exception that mapper function may throw
+     * @param mapper a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *               <a href="package-summary.html#Statelessness">stateless</a>
+     *               function that generates replacement elements. It accepts an element of this
+     *               stream and a consumer that accepts new elements produced from the input element.
+     * @return the new stream
      */
     public IntStreamEx tryMapMultiToInt(ThrowableFunction2_0<? extends Throwable, ? super T, ? super IntConsumer> mapper) {
         Objects.requireNonNull(mapper);
@@ -333,6 +366,11 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #mapMultiToLong(BiConsumer)} but accepts Throwable Functions instead and declares exception
      * may mapper function throw
+     * @param mapper a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *               <a href="package-summary.html#Statelessness">stateless</a>
+     *               function that generates replacement elements. It accepts an element of this
+     *               stream and a consumer that accepts new elements produced from the input element.
+     * @return the new stream
      * @param <X> Exception Type the mapper function may throw
      * @throws X Exception that mapper function may throw
      */
@@ -341,6 +379,11 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     }
     /**
      * Equivalent to {@link #mapMultiToLongThrowing(ThrowableFunction2_0)} but hides the exception that mapper function may throw
+     * @param mapper a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *               <a href="package-summary.html#Statelessness">stateless</a>
+     *               function that generates replacement elements. It accepts an element of this
+     *               stream and a consumer that accepts new elements produced from the input element.
+     * @return the new stream
      */
     public LongStreamEx tryMapMultiToLong(ThrowableFunction2_0<? extends Throwable, ? super T, ? super LongConsumer> mapper) {
         Objects.requireNonNull(mapper);
@@ -368,6 +411,11 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #mapMultiToDouble(BiConsumer)} but accepts Throwable Functions instead and declares exception
      * may mapper function throw
+     * @param mapper a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *               <a href="package-summary.html#Statelessness">stateless</a>
+     *               function that generates replacement elements. It accepts an element of this
+     *               stream and a consumer that accepts new elements produced from the input element.
+     * @return the new stream
      * @param <X> Exception Type the mapper function may throw
      * @throws X Exception that mapper function may throw
      */
@@ -376,6 +424,11 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     }
     /**
      * Equivalent to {@link #mapMultiToDoubleThrowing(ThrowableFunction2_0)} but hides the exception that mapper function may throw
+     * @param mapper a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *               <a href="package-summary.html#Statelessness">stateless</a>
+     *               function that generates replacement elements. It accepts an element of this
+     *               stream and a consumer that accepts new elements produced from the input element.
+     * @return the new stream
      */
     public DoubleStreamEx tryMapMultiToDouble(ThrowableFunction2_0<? extends Throwable, ? super T, ? super DoubleConsumer> mapper) {
         Objects.requireNonNull(mapper);
@@ -389,6 +442,12 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #map(Function)} but accepts Throwable Functions instead and declares exception
      * may mapper function throw
+     * @param <R> The element type of the new stream
+     * @param mapper a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *               <a href="package-summary.html#Statelessness">stateless</a>
+     *               function that generates replacement elements. It accepts an element of this
+     *               stream and a consumer that accepts new elements produced from the input element.
+     * @return the new stream
      * @param <X> Exception Type the mapper function may throw
      * @throws X Exception that mapper function may throw
      */
@@ -397,6 +456,12 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     }
     /**
      * Equivalent to {@link #mapThrowing(ThrowableFunction1_1)} but hides the exception that mapper function may throw
+     * @param <R> The element type of the new stream
+     * @param mapper a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *               <a href="package-summary.html#Statelessness">stateless</a>
+     *               function that generates replacement elements. It accepts an element of this
+     *               stream and a consumer that accepts new elements produced from the input element.
+     * @return the new stream
      */
     public <R> StreamEx<R> tryMap(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends R> mapper ) {
         return map(toFunctionSneakyThrowing(mapper));
@@ -409,6 +474,11 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #mapToInt(ToIntFunction)} but accepts Throwable Functions instead and declares exception
      * may mapper function throw
+     * @param mapper a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *               <a href="package-summary.html#Statelessness">stateless</a>
+     *               function that generates replacement elements. It accepts an element of this
+     *               stream and a consumer that accepts new elements produced from the input element.
+     * @return the new stream
      * @param <X> Exception Type the mapper function may throw
      * @throws X Exception that mapper function may throw
      */
@@ -417,6 +487,11 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     }
     /**
      * Equivalent to {@link #mapToIntThrowing(ThrowableFunction1_1)} but hides the exception that mapper function may throw
+     * @param mapper a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *               <a href="package-summary.html#Statelessness">stateless</a>
+     *               function that generates replacement elements. It accepts an element of this
+     *               stream and a consumer that accepts new elements produced from the input element.
+     * @return the new stream
      */
     public IntStreamEx tryMapToInt(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends Integer> mapper ) {
         return mapToInt(toIntFunctionSneakyThrowing(mapper));
@@ -429,6 +504,11 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #mapToLong(ToLongFunction)} but accepts Throwable Functions instead and declares exception
      * may mapper function throw
+     * @param mapper a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *               <a href="package-summary.html#Statelessness">stateless</a>
+     *               function that generates replacement elements. It accepts an element of this
+     *               stream and a consumer that accepts new elements produced from the input element.
+     * @return the new stream
      * @param <X> Exception Type the mapper function may throw
      * @throws X Exception that mapper function may throw
      */
@@ -437,6 +517,11 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     }
     /**
      * Equivalent to {@link #mapToLongThrowing(ThrowableFunction1_1)} but hides the exception that mapper function may throw
+     * @param mapper a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *               <a href="package-summary.html#Statelessness">stateless</a>
+     *               function that generates replacement elements. It accepts an element of this
+     *               stream and a consumer that accepts new elements produced from the input element.
+     * @return the new stream
      */
     public LongStreamEx tryMapToLong(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends Long> mapper ) {
         return mapToLong(toLongFunctionSneakyThrowing(mapper));
@@ -449,6 +534,11 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #mapToDouble(ToDoubleFunction)} but accepts Throwable Functions instead and declares exception
      * may mapper function throw
+     * @param mapper a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *               <a href="package-summary.html#Statelessness">stateless</a>
+     *               function that generates replacement elements. It accepts an element of this
+     *               stream and a consumer that accepts new elements produced from the input element.
+     * @return the new stream
      * @param <X> Exception Type the mapper function may throw
      * @throws X Exception that mapper function may throw
      */
@@ -457,6 +547,11 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     }
     /**
      * Equivalent to {@link #mapToDoubleThrowing(ThrowableFunction1_1)} but hides the exception that mapper function may throw
+     * @param mapper a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *               <a href="package-summary.html#Statelessness">stateless</a>
+     *               function that generates replacement elements. It accepts an element of this
+     *               stream and a consumer that accepts new elements produced from the input element.
+     * @return the new stream
      */
     public DoubleStreamEx tryMapToDouble(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends Double> mapper ) {
         return mapToDouble(toDoubleFunctionSneakyThrowing(mapper));
@@ -469,6 +564,11 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #flatMapToInt(Function)} but accepts Throwable Functions instead and declares exception
      * may mapper function throw
+     * @param mapper a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *               <a href="package-summary.html#Statelessness">stateless</a>
+     *               function that generates replacement elements. It accepts an element of this
+     *               stream and a consumer that accepts new elements produced from the input element.
+     * @return the new stream
      * @param <X> Exception Type the mapper function may throw
      * @throws X Exception that mapper function may throw
      */
@@ -476,6 +576,11 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
         return tryFlatMapToInt(mapper);
     }
     /**
+     * @param mapper a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *               <a href="package-summary.html#Statelessness">stateless</a>
+     *               function that generates replacement elements. It accepts an element of this
+     *               stream and a consumer that accepts new elements produced from the input element.
+     * @return the new stream
      * Equivalent to {@link #flatMapToIntThrowing(ThrowableFunction1_1)} but hides the exception that mapper function may throw
      */
     public IntStreamEx tryFlatMapToInt(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends IntStream> mapper ) {
@@ -489,6 +594,11 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #flatMapToLong(Function)} but accepts Throwable Functions instead and declares exception
      * may mapper function throw
+     * @param mapper a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *               <a href="package-summary.html#Statelessness">stateless</a>
+     *               function that generates replacement elements. It accepts an element of this
+     *               stream and a consumer that accepts new elements produced from the input element.
+     * @return the new stream
      * @param <X> Exception Type the mapper function may throw
      * @throws X Exception that mapper function may throw
      */
@@ -497,6 +607,11 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     }
     /**
      * Equivalent to {@link #flatMapToLongThrowing(ThrowableFunction1_1)} but hides the exception that mapper function may throw
+     * @param mapper a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *               <a href="package-summary.html#Statelessness">stateless</a>
+     *               function that generates replacement elements. It accepts an element of this
+     *               stream and a consumer that accepts new elements produced from the input element.
+     * @return the new stream
      */
     public LongStreamEx tryFlatMapToLong(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends LongStream> mapper ) {
         return flatMapToLong(toFunctionSneakyThrowing(mapper));
@@ -509,6 +624,11 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #flatMapToDouble(Function)} but accepts Throwable Functions instead and declares exception
      * may mapper function throw
+     * @param mapper a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *               <a href="package-summary.html#Statelessness">stateless</a>
+     *               function that generates replacement elements. It accepts an element of this
+     *               stream and a consumer that accepts new elements produced from the input element.
+     * @return the new stream
      * @param <X> Exception Type the mapper function may throw
      * @throws X Exception that mapper function may throw
      */
@@ -517,6 +637,11 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     }
     /**
      * Equivalent to {@link #flatMapToDoubleThrowing(ThrowableFunction1_1)} but hides the exception that mapper function may throw
+     * @param mapper a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *               <a href="package-summary.html#Statelessness">stateless</a>
+     *               function that generates replacement elements. It accepts an element of this
+     *               stream and a consumer that accepts new elements produced from the input element.
+     * @return the new stream
      */
     public DoubleStreamEx tryFlatMapToDouble(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends DoubleStream> mapper ) {
         return flatMapToDouble(toFunctionSneakyThrowing(mapper));
@@ -646,6 +771,9 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #forEach(Consumer)} but accepts Throwable Functions instead and declares exception
      * may mapper function throw
+     *
+     * @param action a <a href="package-summary.html#NonInterference">
+     *               non-interfering</a> action to perform on the elements
      * @param <X> Exception Type the mapper function may throw
      * @throws X Exception that mapper function may throw
      */
@@ -654,6 +782,8 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     }
     /**
      * Equivalent to {@link #forEachThrowing(ThrowableFunction1_0)} but hides the exception that mapper function may throw
+     * @param action a <a href="package-summary.html#NonInterference">
+     *               non-interfering</a> action to perform on the elements
      */
     public void tryForEach(ThrowableFunction1_0<? extends Throwable, ? super T> action) {
         forEach(toConsumerSneakyThrowing(action));
@@ -677,6 +807,8 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #forEachOrdered(Consumer)} but accepts Throwable Functions instead and declares exception
      * may mapper function throw
+     * @param action a <a href="package-summary.html#NonInterference">
+     *               non-interfering</a> action to perform on the elements
      * @param <X> Exception Type the mapper function may throw
      * @throws X Exception that mapper function may throw
      */
@@ -685,6 +817,8 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     }
     /**
      * Equivalent to {@link #forEachOrderedThrowing(ThrowableFunction1_0)} but hides the exception that mapper function may throw
+     * @param action a <a href="package-summary.html#NonInterference">
+     *               non-interfering</a> action to perform on the elements
      */
     public void tryForEachOrdered(ThrowableFunction1_0<? extends Throwable, ? super T> action) {
         forEachOrdered(toConsumerSneakyThrowing(action));
@@ -711,6 +845,12 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #reduce(Object, BinaryOperator)} but accepts Throwable Functions instead and declares exception
      * may accumulator function throw
+     * @param identity the identity value for the accumulating function
+     * @param accumulator an <a href="package-summary.html#Associativity">associative</a>,
+     *                    <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *                    <a href="package-summary.html#Statelessness">stateless</a>
+     *                    function for combining two values
+     * @return the result of the reduction
      * @param <X> Exception Type the accumulator function may throw
      * @throws X Exception that accumulator function may throw
      */
@@ -719,6 +859,12 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     }
     /**
      * Equivalent to {@link #reduceThrowing(Object, ThrowableBinaryOperator)} but hides the exception that accumulator function may throw
+     * @param identity the identity value for the accumulating function
+     * @param accumulator an <a href="package-summary.html#Associativity">associative</a>,
+     *                    <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *                    <a href="package-summary.html#Statelessness">stateless</a>
+     *                    function for combining two values
+     * @return the result of the reduction
      */
     public T tryReduce(T identity, ThrowableBinaryOperator<? extends Throwable, T> accumulator) {
         return reduce(identity, toBinaryOperatorSneakyThrowing(accumulator));
@@ -733,6 +879,11 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #reduce(BinaryOperator)} but accepts Throwable Functions instead and declares exception
      * may accumulator function throw
+     * @param accumulator an <a href="package-summary.html#Associativity">associative</a>,
+     *                    <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *                    <a href="package-summary.html#Statelessness">stateless</a>
+     *                    function for combining two values
+     * @return the result of the reduction
      * @param <X> Exception Type the accumulator function may throw
      * @throws X Exception that accumulator function may throw
      */
@@ -741,6 +892,11 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     }
     /**
      * Equivalent to {@link #reduceThrowing(ThrowableBinaryOperator)} but hides the exception that accumulator function may throw
+     * @param accumulator an <a href="package-summary.html#Associativity">associative</a>,
+     *                    <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *                    <a href="package-summary.html#Statelessness">stateless</a>
+     *                    function for combining two values
+     * @return the result of the reduction
      */
     public Optional<T> tryReduce(ThrowableBinaryOperator<? extends Throwable, T> accumulator) {
         return reduce(toBinaryOperatorSneakyThrowing(accumulator));
@@ -755,6 +911,18 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #reduce(Object, BiFunction, BinaryOperator)} but accepts Throwable Functions instead and declares exception
      * may accumulator or combiner functions throw
+     * @param identity the identity value for the accumulating function
+     * @param accumulator an <a href="package-summary.html#Associativity">associative</a>,
+     *                    <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *                    <a href="package-summary.html#Statelessness">stateless</a>
+     *                    function for combining two values
+     * @param combiner an <a href="package-summary.html#Associativity">associative</a>,
+     *                    <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *                    <a href="package-summary.html#Statelessness">stateless</a>
+     *                    function for combining two values, which must be
+     *                    compatible with the accumulator function
+     * @return the result of the reduction
+     * @param <U> The type of the result
      * @param <X1> Exception Type the accumulator function may throw
      * @param <X2> Exception Type the combiner function may throw
      * @throws X1 Exception that accumulator function may throw
@@ -765,6 +933,18 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     }
     /**
      * Equivalent to {@link #reduceThrowing(Object, ThrowableFunction2_1, ThrowableBinaryOperator)} but hides the exception that accumulator or combiner function may throw
+     * @param <U> The type of the result
+     * @param identity the identity value for the accumulating function
+     * @param accumulator an <a href="package-summary.html#Associativity">associative</a>,
+     *                    <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *                    <a href="package-summary.html#Statelessness">stateless</a>
+     *                    function for combining two values
+     * @param combiner an <a href="package-summary.html#Associativity">associative</a>,
+     *                    <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *                    <a href="package-summary.html#Statelessness">stateless</a>
+     *                    function for combining two values, which must be
+     *                    compatible with the accumulator function
+     * @return the result of the reduction
      */
     public <U> U tryReduce(U identity, ThrowableFunction2_1<? extends Throwable, U, ? super T, U> accumulator, ThrowableBinaryOperator<? extends Throwable, U> combiner) {
         return reduce(identity, toBiFunctionSneakyThrowing(accumulator), toBinaryOperatorSneakyThrowing(combiner));
@@ -798,6 +978,12 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #reduceWithZero(Object, BinaryOperator)} but accepts Throwable Functions instead and declares exception
      * may accumulator function throw
+     * @param zero zero element
+     * @param accumulator an <a href="package-summary.html#Associativity">associative</a>,
+     *                    <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *                    <a href="package-summary.html#Statelessness">stateless</a>
+     *                    function for combining two values
+     * @return the result of the reduction
      * @param <X> Exception Type the accumulator function may throw
      * @throws X Exception that accumulator function may throw
      */
@@ -806,6 +992,12 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     }
     /**
      * Equivalent to {@link #reduceWithZeroThrowing(Object, ThrowableBinaryOperator)} but hides the exception that accumulator function may throw
+     * @param zero zero element
+     * @param accumulator an <a href="package-summary.html#Associativity">associative</a>,
+     *                    <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *                    <a href="package-summary.html#Statelessness">stateless</a>
+     *                    function for combining two values
+     * @return the result of the reduction
      */
     public Optional<T> tryReduceWithZero(T zero, ThrowableBinaryOperator<? extends Throwable, T> accumulator) {
         return reduceWithZero(zero, toBinaryOperatorSneakyThrowing(accumulator));
@@ -841,6 +1033,13 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #reduceWithZero(Object, Object, BinaryOperator)} but accepts Throwable Functions instead and declares exception
      * may accumulator function throw
+     * @param zero zero element
+     * @param identity the identity value for the accumulating function
+     * @param accumulator an <a href="package-summary.html#Associativity">associative</a>,
+     *                    <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *                    <a href="package-summary.html#Statelessness">stateless</a>
+     *                    function for combining two values
+     * @return the result of the reduction
      * @param <X> Exception Type the accumulator function may throw
      * @throws X Exception that accumulator function may throw
      */
@@ -849,6 +1048,13 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     }
     /**
      * Equivalent to {@link #reduceWithZeroThrowing(Object, Object, ThrowableBinaryOperator)} but hides the exception that accumulator function may throw
+     * @param zero zero element
+     * @param identity the identity value for the accumulating function
+     * @param accumulator an <a href="package-summary.html#Associativity">associative</a>,
+     *                    <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *                    <a href="package-summary.html#Statelessness">stateless</a>
+     *                    function for combining two values
+     * @return the result of the reduction
      */
     public T tryReduceWithZero(T zero, T identity, ThrowableBinaryOperator<? extends Throwable, T> accumulator) {
         return reduceWithZero(zero, identity, toBinaryOperatorSneakyThrowing(accumulator));
@@ -863,6 +1069,24 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #collect(Supplier, BiConsumer, BiConsumer)} but accepts Throwable Functions instead and declares exception
      * may supplier, accumulator or combiner functions throw
+     * @param supplier a function that creates a new mutable result container.
+     *                 For a parallel execution, this function may be called
+     *                 multiple times and must return a fresh value each time.
+     * @param accumulator an <a href="package-summary.html#Associativity">associative</a>,
+     *                    <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *                    <a href="package-summary.html#Statelessness">stateless</a>
+     *                    function that must fold an element into a result
+     *                    container.
+     * @param combiner an <a href="package-summary.html#Associativity">associative</a>,
+     *                    <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *                    <a href="package-summary.html#Statelessness">stateless</a>
+     *                    function that accepts two partial result containers
+     *                    and merges them, which must be compatible with the
+     *                    accumulator function.  The combiner function must fold
+     *                    the elements from the second result container into the
+     *                    first result container.
+     * @return the result of the reduction
+     * @param <R> the type of the mutable result container
      * @param <X1> Exception Type the supplier function may throw
      * @param <X2> Exception Type the accumulator function may throw
      * @param <X3> Exception Type the combiner function may throw
@@ -876,6 +1100,24 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #collectThrowing(ThrowableFunction0_1, ThrowableFunction2_0, ThrowableFunction2_0)} but hides the exception that
      * supplier, accumulator or combiner functions may throw
+     * @param supplier a function that creates a new mutable result container.
+     *                 For a parallel execution, this function may be called
+     *                 multiple times and must return a fresh value each time.
+     * @param accumulator an <a href="package-summary.html#Associativity">associative</a>,
+     *                    <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *                    <a href="package-summary.html#Statelessness">stateless</a>
+     *                    function that must fold an element into a result
+     *                    container.
+     * @param combiner an <a href="package-summary.html#Associativity">associative</a>,
+     *                    <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *                    <a href="package-summary.html#Statelessness">stateless</a>
+     *                    function that accepts two partial result containers
+     *                    and merges them, which must be compatible with the
+     *                    accumulator function.  The combiner function must fold
+     *                    the elements from the second result container into the
+     *                    first result container.
+     * @return the result of the reduction
+     * @param <R> the type of the mutable result container
      */
     public <R> R tryCollect(ThrowableFunction0_1<? extends Throwable, R> supplier, ThrowableFunction2_0<? extends Throwable, R, ? super T> accumulator, ThrowableFunction2_0<? extends Throwable, R, R> combiner) {
         return collect(toSupplierSneakyThrowing(supplier), toBiConsumerSneakyThrowing(accumulator), toBiConsumerSneakyThrowing(combiner));
@@ -964,6 +1206,12 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #count(Predicate)} but accepts Throwable Functions instead and declares exception
      * may predicate function throw
+     * @param predicate a <a
+     *                  href="package-summary.html#NonInterference">non-interfering </a>,
+     *                  <a href="package-summary.html#Statelessness">stateless</a>
+     *                  predicate to apply to stream elements. Only elements passing
+     *                  the predicate will be counted.
+     * @return the count of elements in this stream satisfying the predicate.
      * @param <X> Exception Type the predicate function may throw
      * @throws X Exception that predicate function may throw
      */
@@ -971,6 +1219,12 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
         return tryCount(predicate);
     }
     /**
+     * @param predicate a <a
+     *                  href="package-summary.html#NonInterference">non-interfering </a>,
+     *                  <a href="package-summary.html#Statelessness">stateless</a>
+     *                  predicate to apply to stream elements. Only elements passing
+     *                  the predicate will be counted.
+     * @return the count of elements in this stream satisfying the predicate.
      * Equivalent to {@link #countThrowing(ThrowablePredicate1)} but hides the exception that
      * predicate function may throw
      */
@@ -987,6 +1241,10 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #anyMatch(Predicate)} but accepts Throwable Functions instead and declares exception
      * may predicate function throw
+     * @param predicate a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *                  <a href="package-summary.html#Statelessness">stateless</a>
+     *                  predicate to apply to elements of this stream
+     * @return {@code true} if any elements of the stream match the provided predicate, otherwise {@code false}
      * @param <X> Exception Type the predicate function may throw
      * @throws X Exception that predicate function may throw
      */
@@ -996,6 +1254,10 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #anyMatchThrowing(ThrowablePredicate1)} but hides the exception that
      * predicate function may throw
+     * @param predicate a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *                  <a href="package-summary.html#Statelessness">stateless</a>
+     *                  predicate to apply to elements of this stream
+     * @return {@code true} if any elements of the stream match the provided predicate, otherwise {@code false}
      */
     public boolean tryAnyMatch(ThrowablePredicate1<? extends Throwable, ? super T> predicate) {
         return anyMatch(toPredicateSneakyThrowing(predicate));
@@ -1010,6 +1272,10 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #allMatch(Predicate)} but accepts Throwable Functions instead and declares exception
      * may predicate function throw
+     * @param predicate a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *                  <a href="package-summary.html#Statelessness">stateless</a>
+     *                  predicate to apply to elements of this stream
+     * @return {@code true} if all elements of the stream match the provided predicate, otherwise {@code false}
      * @param <X> Exception Type the predicate function may throw
      * @throws X Exception that predicate function may throw
      */
@@ -1019,6 +1285,10 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #allMatchThrowing(ThrowablePredicate1)} but hides the exception that
      * predicate function may throw
+     * @param predicate a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *                  <a href="package-summary.html#Statelessness">stateless</a>
+     *                  predicate to apply to elements of this stream
+     * @return {@code true} if all elements of the stream match the provided predicate, otherwise {@code false}
      */
     public boolean tryAllMatch(ThrowablePredicate1<? extends Throwable, ? super T> predicate) {
         return allMatch(toPredicateSneakyThrowing(predicate));
@@ -1031,6 +1301,10 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #noneMatch(Predicate)} but accepts Throwable Functions instead and declares exception
      * may predicate function throw
+     * @param predicate a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *                  <a href="package-summary.html#Statelessness">stateless</a>
+     *                  predicate to apply to elements of this stream
+     * @return {@code true} if none element of the stream match the provided predicate, otherwise {@code false}
      * @param <X> Exception Type the predicate function may throw
      * @throws X Exception that predicate function may throw
      */
@@ -1040,6 +1314,10 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #noneMatchThrowing(ThrowablePredicate1)} but hides the exception that
      * predicate function may throw
+     * @param predicate a <a href="package-summary.html#NonInterference">non-interfering</a>,
+     *                  <a href="package-summary.html#Statelessness">stateless</a>
+     *                  predicate to apply to elements of this stream
+     * @return {@code true} if none element of the stream match the provided predicate, otherwise {@code false}
      */
     public boolean tryNoneMatch(ThrowablePredicate1<? extends Throwable, ? super T> predicate) {
         return noneMatch(toPredicateSneakyThrowing(predicate));
@@ -1116,6 +1394,13 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #indexOf(Predicate)} but accepts Throwable Functions instead and declares exception
      * may predicate function throw
+     * @param predicate a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        predicate which returned value should match
+     * @return an {@code OptionalLong} describing the index of the first
+     *         matching element of this stream, or an empty {@code OptionalLong}
+     *         if there's no matching element.
      * @param <X> Exception Type the predicate function may throw
      * @throws X Exception that predicate function may throw
      */
@@ -1125,6 +1410,13 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #indexOfThrowing(ThrowablePredicate1)} but hides the exception that
      * predicate function may throw
+     * @param predicate a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        predicate which returned value should match
+     * @return an {@code OptionalLong} describing the index of the first
+     *         matching element of this stream, or an empty {@code OptionalLong}
+     *         if there's no matching element.
      */
     public OptionalLong tryIndexOf(ThrowablePredicate1<? extends Throwable, ? super T> predicate) {
         return indexOf(toPredicateSneakyThrowing(predicate));
@@ -1162,6 +1454,13 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #flatCollection(Function)} but accepts Throwable Functions instead and declares exception
      * may mapper function throw
+     * @param mapper a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function to apply to each element which produces a
+     *        {@link Collection} of new values
+     * @return the new stream
+     * @param <R> The element type of the new stream
      * @param <X> Exception Type the mapper function may throw
      * @throws X Exception that mapper function may throw
      */
@@ -1171,6 +1470,13 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #flatCollectionThrowing(ThrowableFunction1_1)} but hides the exception that
      * mapper function may throw
+     * @param <R> The element type of the new stream
+     * @param mapper a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function to apply to each element which produces a
+     *        {@link Collection} of new values
+     * @return the new stream
      */
     public <R> StreamEx<R> tryFlatCollection(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends Collection<? extends R>> mapper) {
         return flatCollection(toFunctionSneakyThrowing(mapper));
@@ -1209,6 +1515,13 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #flatArray(Function)} but accepts Throwable Functions instead and declares exception
      * may mapper function throw
+     * @param mapper a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function to apply to each element which produces an
+     *        array of new values
+     * @return the new stream
+     * @param <R> The element type of the new stream
      * @param <X> Exception Type the mapper function may throw
      * @throws X Exception that mapper function may throw
      */
@@ -1218,6 +1531,13 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #flatArrayThrowing(ThrowableFunction1_1)} but hides the exception that
      * mapper function may throw
+     * @param <R> The element type of the new stream
+     * @param mapper a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function to apply to each element which produces an
+     *        array of new values
+     * @return the new stream
      */
     public <R> StreamEx<R> tryFlatArray(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends R[]> mapper) {
         return flatArray(toFunctionSneakyThrowing(mapper));
@@ -1257,6 +1577,13 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #mapPartial(Function)} but accepts Throwable Functions instead and declares exception
      * may mapper function throw
+     * @param <R> The element type of the new stream
+     * @param mapper a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        partial function to apply to each element which returns a present optional
+     *        if it's applicable, or an empty optional otherwise
+     * @return the new stream
      * @param <X> Exception Type the mapper function may throw
      * @throws X Exception that mapper function may throw
      */
@@ -1266,6 +1593,13 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #mapPartialThrowing(ThrowableFunction1_1)} but hides the exception that
      * mapper function may throw
+     * @param <R> The element type of the new stream
+     * @param mapper a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        partial function to apply to each element which returns a present optional
+     *        if it's applicable, or an empty optional otherwise
+     * @return the new stream
      */
     public <R> StreamEx<R> tryMapPartial(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends Optional<? extends R>> mapper) {
         return mapPartial(toFunctionSneakyThrowing(mapper));
@@ -1296,6 +1630,10 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #pairMap(BiFunction)} but accepts Throwable Functions instead and declares exception
      * may mapper function throw
+     * @param mapper a non-interfering, stateless function to apply to each
+     *        adjacent pair of this stream elements.
+     * @return the new stream
+     * @param <R> The element type of the new stream
      * @param <X> Exception Type the mapper function may throw
      * @throws X Exception that mapper function may throw
      */
@@ -1305,6 +1643,10 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #pairMapThrowing(ThrowableFunction2_1)} but hides the exception that
      * mapper function may throw
+     * @param <R> The element type of the new stream
+     * @param mapper a non-interfering, stateless function to apply to each
+     *        adjacent pair of this stream elements.
+     * @return the new stream
      */
     public <R> StreamEx<R> tryPairMap(ThrowableFunction2_1<? extends Throwable, ? super T, ? super T, ? extends R> mapper) {
         return pairMap(toBiFunctionSneakyThrowing(mapper));
@@ -1949,6 +2291,10 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
      * Equivalent to {@link #toListAndThen(Function)} but accepts Throwable Functions instead and declares exception
      * may finisher function throw
      * @param <X> Exception Type the finisher function may throw
+     * @param <R> the type of the result
+     * @param finisher a function to be applied to the intermediate list
+     * @return result of applying the finisher transformation to the list of the
+     *         stream elements.
      * @throws X Exception that finisher function may throw
      */
     public <X extends Throwable, R> R toListAndThenThrowing(ThrowableFunction1_1<X, ? super List<T>, R> finisher) throws X {
@@ -1957,6 +2303,10 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #toListAndThenThrowing(ThrowableFunction1_1)} but hides the exception that
      * finisher function may throw
+     * @param <R> the type of the result
+     * @param finisher a function to be applied to the intermediate list
+     * @return result of applying the finisher transformation to the list of the
+     *         stream elements.
      */
     public <R> R toListAndThenTry(ThrowableFunction1_1<? extends Throwable, ? super List<T>, R> finisher) {
         return toListAndThen(toFunctionSneakyThrowing(finisher));
@@ -2045,6 +2395,10 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
      * Equivalent to {@link #toSetAndThen(Function)} but accepts Throwable Functions instead and declares exception
      * may finisher function throw
      * @param <X> Exception Type the finisher function may throw
+     * @param <R> the result type
+     * @param finisher a function to be applied to the intermediate {@code Set}
+     * @return result of applying the finisher transformation to the {@code Set}
+     *         of the stream elements.
      * @throws X Exception that finisher function may throw
      */
     public <X extends Throwable, R> R toSetAndThenThrowing(ThrowableFunction1_1<X, ? super Set<T>, R> finisher) throws X {
@@ -2053,6 +2407,10 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #toSetAndThenThrowing(ThrowableFunction1_1)} but hides the exception that
      * finisher function may throw
+     * @param <R> the result type
+     * @param finisher a function to be applied to the intermediate {@code Set}
+     * @return result of applying the finisher transformation to the {@code Set}
+     *         of the stream elements.
      */
     public <R> R toSetAndThenTry(ThrowableFunction1_1<? extends Throwable, ? super Set<T>, R> finisher) {
         return toSetAndThen(toFunctionSneakyThrowing(finisher));
@@ -2087,6 +2445,13 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
      * may collectionFactory or finisher functions throw
      * @param <X1> Exception Type the collectionFactory function may throw
      * @param <X2> Exception Type the finisher function may throw
+     * @param <C> the type of the resulting {@code Collection}
+     * @param <R> the result type
+     * @param collectionFactory a {@code Supplier} which returns a new, empty
+     *        {@code Collection} of the appropriate type
+     * @param finisher a function to be applied to the intermediate {@code Collection}
+     * @return result of applying the finisher transformation to the {@code Collection}
+     *         of the stream elements.
      * @throws X1 Exception that collectionFactory function may throw
      * @throws X2 Exception that finisher function may throw
      */
@@ -2096,6 +2461,13 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #toCollectionAndThenThrowing(ThrowableFunction0_1, ThrowableFunction1_1)} but hides the exception that
      * collectionFactory or finisher functions may throw
+     * @param <C> the type of the resulting {@code Collection}
+     * @param <R> the result type
+     * @param collectionFactory a {@code Supplier} which returns a new, empty
+     *        {@code Collection} of the appropriate type
+     * @param finisher a function to be applied to the intermediate {@code Collection}
+     * @return result of applying the finisher transformation to the {@code Collection}
+     *         of the stream elements.
      */
     public <C extends Collection<T>, R> R toCollectionAndThenTry(ThrowableFunction0_1<? extends Throwable, C> collectionFactory, ThrowableFunction1_1<? extends Throwable, ? super C, R> finisher) {
         return toCollectionAndThen(toSupplierSneakyThrowing(collectionFactory), toFunctionSneakyThrowing(finisher));
@@ -2122,6 +2494,10 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
      * Equivalent to {@link #toCollection(Supplier)} but accepts Throwable Functions instead and declares exception
      * may collectionFactory function throw
      * @param <X> Exception Type the collectionFactory function may throw
+     * @param <C> the type of the resulting {@code Collection}
+     * @param collectionFactory a {@code Supplier} which returns a new, empty
+     *        {@code Collection} of the appropriate type
+     * @return a {@code Collection} containing the elements of this stream
      * @throws X Exception that collectionFactory function may throw
      */
     public <X extends Throwable, C extends Collection<T>> C toCollectionThrowing(ThrowableFunction0_1<X, C> collectionFactory) throws X {
@@ -2130,6 +2506,10 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #toCollectionThrowing(ThrowableFunction0_1)} but hides the exception that
      * collectionFactory function may throw
+     * @param <C> the type of the resulting {@code Collection}
+     * @param collectionFactory a {@code Supplier} which returns a new, empty
+     *        {@code Collection} of the appropriate type
+     * @return a {@code Collection} containing the elements of this stream
      */
     public <C extends Collection<T>> C tryToCollection(ThrowableFunction0_1<? extends Throwable, C> collectionFactory) {
         return toCollection(toSupplierSneakyThrowing(collectionFactory));
@@ -2182,6 +2562,13 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
      * Equivalent to {@link #foldLeft(Object, BiFunction)} but accepts Throwable Functions instead and declares exception
      * may accumulator function throw
      * @param <X> Exception Type the accumulator function may throw
+     * @param <U> The type of the result
+     * @param seed the starting value
+     * @param accumulator a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function for incorporating an additional element into a result
+     * @return the result of the folding
      * @throws X Exception that accumulator function may throw
      */
     public <X extends Throwable, U> U foldLeftThrowing(U seed, ThrowableFunction2_1<X, U, ? super T, U> accumulator) throws X {
@@ -2190,6 +2577,13 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #foldLeftThrowing(Object, ThrowableFunction2_1)} but hides the exception that
      * accumulator function may throw
+     * @param <U> The type of the result
+     * @param seed the starting value
+     * @param accumulator a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function for incorporating an additional element into a result
+     * @return the result of the folding
      */
     public <U> U tryFoldLeft(U seed, ThrowableFunction2_1<? extends Throwable, U, ? super T, U> accumulator) {
         return foldLeft(seed, toBiFunctionSneakyThrowing(accumulator));
@@ -2246,6 +2640,11 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
      * Equivalent to {@link #foldLeft(BinaryOperator)} but accepts Throwable Functions instead and declares exception
      * may accumulator function throw
      * @param <X> Exception Type the accumulator function may throw
+     * @param accumulator a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function for incorporating an additional element into a result
+     * @return the result of the folding
      * @throws X Exception that accumulator function may throw
      */
     public <X extends Throwable> Optional<T> foldLeftThrowing(ThrowableBinaryOperator<X, T> accumulator) throws X {
@@ -2254,6 +2653,11 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #foldLeftThrowing(ThrowableBinaryOperator)} but hides the exception that
      * accumulator function may throw
+     * @param accumulator a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function for incorporating an additional element into a result
+     * @return the result of the folding
      */
     public Optional<T> tryFoldLeft(ThrowableBinaryOperator<? extends Throwable, T> accumulator) {
         return foldLeft(toBinaryOperatorSneakyThrowing(accumulator));
@@ -2302,6 +2706,13 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
      * Equivalent to {@link #foldRight(Object, BiFunction)} but accepts Throwable Functions instead and declares exception
      * may accumulator function throw
      * @param <X> Exception Type the accumulator function may throw
+     * @param <U> The type of the result
+     * @param seed the starting value
+     * @param accumulator a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function for incorporating an additional element into a result
+     * @return the result of the folding
      * @throws X Exception that accumulator function may throw
      */
     public <X extends Throwable, U> U foldRightThrowing(U seed, ThrowableFunction2_1<X, ? super T, U, U> accumulator) throws X {
@@ -2310,6 +2721,13 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #foldRightThrowing(Object, ThrowableFunction2_1)} but hides the exception that
      * accumulator function may throw
+     * @param <U> The type of the result
+     * @param seed the starting value
+     * @param accumulator a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function for incorporating an additional element into a result
+     * @return the result of the folding
      */
     public <U> U tryFoldRight(U seed, ThrowableFunction2_1<? extends Throwable, ? super T, U, U> accumulator) {
         return foldRight(seed, toBiFunctionSneakyThrowing(accumulator));
@@ -2358,6 +2776,11 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
      * Equivalent to {@link #foldRight(BinaryOperator)} but accepts Throwable Functions instead and declares exception
      * may accumulator function throw
      * @param <X> Exception Type the accumulator function may throw
+     * @param accumulator a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function for incorporating an additional element into a result
+     * @return the result of the folding
      * @throws X Exception that accumulator function may throw
      */
     public <X extends Throwable> Optional<T> foldRightThrowing(ThrowableBinaryOperator<X, T> accumulator) throws X {
@@ -2366,6 +2789,11 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #foldRightThrowing(ThrowableBinaryOperator)} but hides the exception that
      * accumulator function may throw
+     * @param accumulator a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function for incorporating an additional element into a result
+     * @return the result of the folding
      */
     public Optional<T> tryFoldRight(ThrowableBinaryOperator<? extends Throwable, T> accumulator) {
         return foldRight(toBinaryOperatorSneakyThrowing(accumulator));
@@ -2414,6 +2842,17 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
      * Equivalent to {@link #scanLeft(Object, BiFunction)} but accepts Throwable Functions instead and declares exception
      * may accumulator function throw
      * @param <X> Exception Type the accumulator function may throw
+     * @param <U> The type of the result
+     * @param seed the starting value
+     * @param accumulator a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function for incorporating an additional element into a result
+     * @return the {@code List} where the first element is the seed and every
+     *         successor element is the result of applying accumulator function
+     *         to the previous list element and the corresponding stream
+     *         element. The resulting list is one element longer than this
+     *         stream.
      * @throws X Exception that accumulator function may throw
      */
     public <X extends Throwable, U> List<U> scanLeftThrowing(U seed, ThrowableFunction2_1<X, U, ? super T, U> accumulator) throws X {
@@ -2422,6 +2861,17 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #scanLeftThrowing(Object, ThrowableFunction2_1)} but hides the exception that
      * accumulator function may throw
+     * @param <U> The type of the result
+     * @param seed the starting value
+     * @param accumulator a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function for incorporating an additional element into a result
+     * @return the {@code List} where the first element is the seed and every
+     *         successor element is the result of applying accumulator function
+     *         to the previous list element and the corresponding stream
+     *         element. The resulting list is one element longer than this
+     *         stream.
      */
     public <U> List<U> tryScanLeft(U seed, ThrowableFunction2_1<? extends Throwable, U, ? super T, U> accumulator) {
         return scanLeft(seed, toBiFunctionSneakyThrowing(accumulator));
@@ -2473,6 +2923,15 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
      * Equivalent to {@link #scanLeft(BinaryOperator)} but accepts Throwable Functions instead and declares exception
      * may accumulator function throw
      * @param <X> Exception Type the accumulator function may throw
+     * @param accumulator a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function for incorporating an additional element into a result
+     * @return the {@code List} where the first element is the first element of
+     *         this stream and every successor element is the result of applying
+     *         accumulator function to the previous list element and the
+     *         corresponding stream element. The resulting list has the same
+     *         size as this stream.
      * @throws X Exception that accumulator function may throw
      */
     public <X extends Throwable> List<T> scanLeftThrowing(ThrowableBinaryOperator<X, T> accumulator) throws X {
@@ -2481,6 +2940,15 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #scanLeftThrowing(ThrowableBinaryOperator)} but hides the exception that
      * accumulator function may throw
+     * @param accumulator a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function for incorporating an additional element into a result
+     * @return the {@code List} where the first element is the first element of
+     *         this stream and every successor element is the result of applying
+     *         accumulator function to the previous list element and the
+     *         corresponding stream element. The resulting list has the same
+     *         size as this stream.
      */
     public List<T> tryScanLeft(ThrowableBinaryOperator<? extends Throwable, T> accumulator) {
         return scanLeft(toBinaryOperatorSneakyThrowing(accumulator));
@@ -2535,6 +3003,17 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
      * Equivalent to {@link #scanRight(Object, BiFunction)} but accepts Throwable Functions instead and declares exception
      * may accumulator function throw
      * @param <X> Exception Type the accumulator function may throw
+     * @param <U> The type of the result
+     * @param seed the starting value
+     * @param accumulator a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function for incorporating an additional element into a result
+     * @return the {@code List} where the last element is the seed and every
+     *         predecessor element is the result of applying accumulator
+     *         function to the corresponding stream element and the next list
+     *         element. The resulting list is one element longer than this
+     *         stream.
      * @throws X Exception that accumulator function may throw
      */
     public <X extends Throwable, U> List<U> scanRightThrowing(U seed, ThrowableFunction2_1<X, ? super T, U, U> accumulator) throws X {
@@ -2543,6 +3022,17 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #scanRightThrowing(Object, ThrowableFunction2_1)} but hides the exception that
      * accumulator function may throw
+     * @param <U> The type of the result
+     * @param seed the starting value
+     * @param accumulator a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function for incorporating an additional element into a result
+     * @return the {@code List} where the last element is the seed and every
+     *         predecessor element is the result of applying accumulator
+     *         function to the corresponding stream element and the next list
+     *         element. The resulting list is one element longer than this
+     *         stream.
      */
     public <U> List<U> tryScanRight(U seed, ThrowableFunction2_1<? extends Throwable, ? super T, U, U> accumulator) {
         return scanRight(seed, toBiFunctionSneakyThrowing(accumulator));
@@ -2591,6 +3081,15 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
      * Equivalent to {@link #scanRight(BinaryOperator)} but accepts Throwable Functions instead and declares exception
      * may accumulator function throw
      * @param <X> Exception Type the accumulator function may throw
+     * @param accumulator a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function for incorporating an additional element into a result
+     * @return the {@code List} where the last element is the last element of
+     *         this stream and every predecessor element is the result of
+     *         applying accumulator function to the corresponding stream element
+     *         and the next list element. The resulting list is one element
+     *         longer than this stream.
      * @throws X Exception that accumulator function may throw
      */
     public <X extends Throwable> List<T> scanRightThrowing(ThrowableBinaryOperator<X, T> accumulator) throws X {
@@ -2599,6 +3098,15 @@ public abstract class AbstractStreamEx<T, S extends AbstractStreamEx<T, S>> exte
     /**
      * Equivalent to {@link #scanRightThrowing(ThrowableBinaryOperator)} but hides the exception that
      * accumulator function may throw
+     * @param accumulator a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function for incorporating an additional element into a result
+     * @return the {@code List} where the last element is the last element of
+     *         this stream and every predecessor element is the result of
+     *         applying accumulator function to the corresponding stream element
+     *         and the next list element. The resulting list is one element
+     *         longer than this stream.
      */
     public List<T> tryScanRight(ThrowableBinaryOperator<? extends Throwable, T> accumulator) {
         return scanRight(toBinaryOperatorSneakyThrowing(accumulator));

--- a/src/main/java/one/util/streamex/InternalUtilities.java
+++ b/src/main/java/one/util/streamex/InternalUtilities.java
@@ -1,0 +1,181 @@
+package one.util.streamex;
+
+import one.util.functionex.*;
+
+import java.util.Map;
+import java.util.function.*;
+
+class InternalUtilities {
+    @SuppressWarnings("unchecked")
+    public static <T extends Throwable, R> R sneakyThrow(Throwable t) throws T {
+        throw (T) t;
+    }
+    public static Runnable toRunnableSneakyThrowing(ThrowableFunction0_0<? extends Throwable> action) {
+        return () -> {
+            try {
+                action.apply();
+            } catch (Throwable e) {
+                sneakyThrow(e);
+            }
+        };
+    }
+    public static <T> Consumer<T> toConsumerSneakyThrowing(ThrowableFunction1_0<? extends Throwable, ? super T> action) {
+        return element -> {
+            try {
+                action.apply(element);
+            } catch (Throwable e) {
+                sneakyThrow(e);
+            }
+        };
+    }
+    public static <T1, T2> BiConsumer<T1, T2> toBiConsumerSneakyThrowing(ThrowableFunction2_0<? extends Throwable, ? super T1, ? super T2> action) {
+        return (t1, t2) -> {
+            try {
+                action.apply(t1, t2);
+            } catch (Throwable e) {
+                sneakyThrow(e);
+            }
+        };
+    }
+    public static <R> Supplier<R> toSupplierSneakyThrowing(ThrowableFunction0_1<? extends Throwable, ? extends R> action) {
+        return () -> {
+            try {
+                return action.apply();
+            } catch (Throwable e) {
+                return sneakyThrow(e);
+            }
+        };
+    }
+    public static <T, R> Function<T, R> toFunctionSneakyThrowing(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends R> action) {
+        return element -> {
+            try {
+                return action.apply(element);
+            } catch (Throwable e) {
+                return sneakyThrow(e);
+            }
+        };
+    }
+    public static <T> ToIntFunction<T> toIntFunctionSneakyThrowing(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends Integer> action) {
+        return element -> {
+            try {
+                return action.apply(element);
+            } catch (Throwable e) {
+                return sneakyThrow(e);
+            }
+        };
+    }
+    public static <T> ToLongFunction<T> toLongFunctionSneakyThrowing(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends Long> action) {
+        return element -> {
+            try {
+                return action.apply(element);
+            } catch (Throwable e) {
+                return sneakyThrow(e);
+            }
+        };
+    }
+    public static <T> ToDoubleFunction<T> toDoubleFunctionSneakyThrowing(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends Double> action) {
+        return element -> {
+            try {
+                return action.apply(element);
+            } catch (Throwable e) {
+                return sneakyThrow(e);
+            }
+        };
+    }
+    public static <T1, T2, R> BiFunction<T1, T2, R> toBiFunctionSneakyThrowing(ThrowableFunction2_1<? extends Throwable, ? super T1, ? super T2, ? extends R> action) {
+        return (t1, t2) -> {
+            try {
+                return action.apply(t1, t2);
+            } catch (Throwable e) {
+                return sneakyThrow(e);
+            }
+        };
+    }
+    public static <T1, T2> ToIntBiFunction<T1, T2> toIntBiFunctionSneakyThrowing(ThrowableFunction2_1<? extends Throwable, ? super T1, ? super T2, ? extends Integer> action) {
+        return (t1, t2) -> {
+            try {
+                return action.apply(t1, t2);
+            } catch (Throwable e) {
+                return sneakyThrow(e);
+            }
+        };
+    }
+    public static <T1, T2> ToLongBiFunction<T1, T2> toLongBiFunctionSneakyThrowing(ThrowableFunction2_1<? extends Throwable, ? super T1, ? super T2, ? extends Long> action) {
+        return (t1, t2) -> {
+            try {
+                return action.apply(t1, t2);
+            } catch (Throwable e) {
+                return sneakyThrow(e);
+            }
+        };
+    }
+    public static <T1, T2> ToDoubleBiFunction<T1, T2> toDoubleBiFunctionSneakyThrowing(ThrowableFunction2_1<? extends Throwable, ? super T1, ? super T2, ? extends Double> action) {
+        return (t1, t2) -> {
+            try {
+                return action.apply(t1, t2);
+            } catch (Throwable e) {
+                return sneakyThrow(e);
+            }
+        };
+    }
+
+    public static <T> BinaryOperator<T> toBinaryOperatorSneakyThrowing(ThrowableBinaryOperator<? extends Throwable, T> operator) {
+        return (t1, t2) -> {
+            try {
+                return operator.apply(t1, t2);
+            } catch (Throwable e) {
+                return sneakyThrow(e);
+            }
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <R1, R2> Supplier<? extends Map.Entry<R1, R2>> toEntrySupplierSneakyThrowing(ThrowableFunction0_2<? extends Throwable, ? extends R1, ? extends R2> provider) {
+        return () -> {
+            try {
+                return (Map.Entry<R1, R2>) provider.apply();
+            } catch (Throwable e) {
+                return sneakyThrow(e);
+            }
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T, R1, R2> Function<T, Map.Entry<R1, R2>> toEntryFunctionSneakyThrowing(ThrowableFunction1_2<? extends Throwable, ? super T, ? extends R1, ? extends R2> function) {
+        return element -> {
+            try {
+                return (Map.Entry<R1, R2>) function.apply(element);
+            } catch (Throwable e) {
+                return sneakyThrow(e);
+            }
+        };
+    }
+    @SuppressWarnings("unchecked")
+    public static <T1, T2, R1, R2> BiFunction<T1, T2, Map.Entry<R1, R2>> toEntryBiFunctionSneakyThrowing(ThrowableFunction2_2<? extends Throwable, ? super T1, ? super T2, ? extends R1, ? extends R2> function) {
+        return (t1, t2) -> {
+            try {
+                return (Map.Entry<R1, R2>) function.apply(t1, t2);
+            } catch (Throwable e) {
+                return sneakyThrow(e);
+            }
+        };
+    }
+    public static <T> Predicate<T> toPredicateSneakyThrowing(ThrowablePredicate1<? extends Throwable, ? super T> predicate) {
+        return element -> {
+            try {
+                return predicate.test(element);
+            } catch (Throwable e) {
+                return sneakyThrow(e);
+            }
+        };
+    }
+    public static <T1, T2> BiPredicate<T1, T2> toBiPredicateSneakyThrowing(ThrowablePredicate2<? extends Throwable, ? super T1, ? super T2> predicate) {
+        return (t1, t2) -> {
+            try {
+                return predicate.test(t1, t2);
+            } catch (Throwable e) {
+                return sneakyThrow(e);
+            }
+        };
+    }
+}

--- a/src/main/java/one/util/streamex/StreamEx.java
+++ b/src/main/java/one/util/streamex/StreamEx.java
@@ -15,6 +15,7 @@
  */
 package one.util.streamex;
 
+import one.util.functionex.ThrowableBinaryOperator;
 import one.util.functionex.ThrowableFunction1_1;
 import one.util.functionex.ThrowableFunction1_2;
 
@@ -211,19 +212,70 @@ public final class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
     public <V> EntryStream<T, V> mapNewValue(Function<? super T, ? extends V> valueMapper) {
         return new EntryStream<>(stream().map(e -> new SimpleImmutableEntry<>(e, valueMapper.apply(e))), context);
     }
+    /**
+     * Equivalent to {@link #mapNewValueThrowing(ThrowableFunction1_1)} but accepts Throwable Functions instead and declares exception
+     * may accumulator function throw
+     * @param <X> Exception Type the valueMapper function may throw
+     * @param <V> The {@code Entry} value type
+     * @param valueMapper a non-interfering, stateless function to apply to each
+     *        element
+     * @return the new stream
+     * @throws X Exception that valueMapper function may throw
+     */
     public <X extends Throwable, V> EntryStream<T, V> mapNewValueThrowing(ThrowableFunction1_1<X, ? super T, ? extends V> valueMapper) throws X {
         return tryMapNewValue(valueMapper);
     }
+
+    /**
+     * Equivalent to {@link #mapNewValueThrowing(ThrowableFunction1_1)} but hides the exception that
+     * accumulator function may throw
+     * @param <V> The {@code Entry} value type
+     * @param valueMapper a non-interfering, stateless function to apply to each
+     *        element
+     * @return the new stream
+     */
     public <V> EntryStream<T, V> tryMapNewValue(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends V> valueMapper) {
         return mapNewValue(toFunctionSneakyThrowing(valueMapper));
     }
 
+    /**
+     * Returns an {@link EntryStream} consisting of the {@link Entry} objects
+     * which keys and values are results of applying the given function to the
+     * elements of this stream.
+     *
+     * <p>
+     * This is an <a href="package-summary.html#StreamOps">intermediate</a>
+     * operation.
+     *
+     * @param <U> The {@code Entry} key type
+     * @param <V> The {@code Entry} value type
+     * @param entryMapper a non-interfering, stateless function to apply to each element
+     * @return the new stream
+     */
     public <U, V> EntryStream<U, V> mapToEntry(Function<? super T, ? extends Entry<U, V>> entryMapper) {
         return new EntryStream<>(stream().map(entryMapper), context);
     }
+    /**
+     * Equivalent to {@link #mapToEntry(Function)} but accepts Throwable Functions instead and declares exception
+     * may accumulator function throw
+     * @param <X> Exception Type the valueMapper function may throw
+     * @param <U> The {@code Entry} key type
+     * @param <V> The {@code Entry} value type
+     * @param entryMapper a non-interfering, stateless function to apply to each element
+     * @return the new stream
+     * @throws X Exception that valueMapper function may throw
+     */
     public <X extends Throwable, U, V> EntryStream<U, V> mapToEntryThrowing(ThrowableFunction1_2<X, ? super T, ? extends U, ? extends V> entryMapper) throws X {
         return tryMapToEntry(entryMapper);
     }
+    /**
+     * Equivalent to {@link #mapToEntryThrowing(ThrowableFunction1_2)} but hides the exception that
+     * accumulator function may throw
+     * @param <U> The {@code Entry} key type
+     * @param <V> The {@code Entry} value type
+     * @param entryMapper a non-interfering, stateless function to apply to each element
+     * @return the new stream
+     */
     public <U, V> EntryStream<U, V> tryMapToEntry(ThrowableFunction1_2<? extends Throwable, ? super T, ? extends U, ? extends V> entryMapper) {
         return mapToEntry(toEntryFunctionSneakyThrowing(entryMapper));
     }
@@ -250,10 +302,36 @@ public final class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
         return new EntryStream<>(stream()
                 .map(e -> new SimpleImmutableEntry<>(keyMapper.apply(e), valueMapper.apply(e))), context);
     }
+    /**
+     * Equivalent to {@link #mapToEntry(Function)} but accepts Throwable Functions instead and declares exception
+     * may accumulator function throw
+     * @param <X1> Exception Type the keyMapper function may throw
+     * @param <X2> Exception Type the valueMapper function may throw
+     * @param <K> The {@code Entry} key type
+     * @param <V> The {@code Entry} value type
+     * @param keyMapper a non-interfering, stateless function to apply to each
+     *        element
+     * @param valueMapper a non-interfering, stateless function to apply to each
+     *        element
+     * @return the new stream
+     * @throws X1 Exception that keyMapper function may throw
+     * @throws X2 Exception that valueMapper function may throw
+     */
     public <X1 extends Throwable, X2 extends Throwable, K, V> EntryStream<K, V> mapToEntryThrowing(ThrowableFunction1_1<X1, ? super T, ? extends K> keyMapper,
             ThrowableFunction1_1<X2, ? super T, ? extends V> valueMapper) throws X1, X2{
         return tryMapToEntry(keyMapper, valueMapper);
     }
+    /**
+     * Equivalent to {@link #mapToEntryThrowing(ThrowableFunction1_2)} but hides the exception that
+     * accumulator function may throw
+     * @param <K> The {@code Entry} key type
+     * @param <V> The {@code Entry} value type
+     * @param keyMapper a non-interfering, stateless function to apply to each
+     *        element
+     * @param valueMapper a non-interfering, stateless function to apply to each
+     *        element
+     * @return the new stream
+     */
     public <K, V> EntryStream<K, V> tryMapToEntry(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends K> keyMapper,
             ThrowableFunction1_1<? extends Throwable, ? super T, ? extends V> valueMapper) {
         return mapToEntry(toFunctionSneakyThrowing(keyMapper), toFunctionSneakyThrowing(valueMapper));
@@ -278,14 +356,34 @@ public final class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
     public StreamEx<T> mapFirst(Function<? super T, ? extends T> mapper) {
         return supply(new PairSpliterator.PSOfRef<>(mapper, spliterator(), true));
     }
+    /**
+     * Equivalent to {@link #mapFirst(Function)} but accepts Throwable Functions instead and declares exception
+     * may mapper function throw
+     * @param <X> Exception Type the mapper function may throw
+     * @param mapper a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function to apply to the first element
+     * @return the new stream
+     * @throws X Exception that mapper function may throw
+     */
     public <X extends Throwable> StreamEx<T> mapFirstThrowing(ThrowableFunction1_1<X, ? super T, ? extends T> mapper) throws X{
         return tryMapFirst(mapper);
     }
+    /**
+     * Equivalent to {@link #mapFirstThrowing(ThrowableFunction1_1)} but hides the exception that
+     * mapper function may throw
+     * @param mapper a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function to apply to the first element
+     * @return the new stream
+     */
     public StreamEx<T> tryMapFirst(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends T> mapper) {
         return mapFirst(toFunctionSneakyThrowing(mapper));
     }
 
-    /**
+    /**.
      * Returns a stream where the first element is transformed using
      * {@code firstMapper} function and other elements are transformed using
      * {@code notFirstMapper} function.
@@ -311,9 +409,41 @@ public final class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
             Function<? super T, ? extends R> notFirstMapper) {
         return new StreamEx<>(new PairSpliterator.PSOfRef<>(firstMapper, notFirstMapper, spliterator(), true), context);
     }
+    /**
+     * Equivalent to {@link #mapFirstOrElse(Function, Function)} but accepts Throwable Functions instead and declares exception
+     * may mappers functions throw
+     * @param <X1> Exception Type the firstMapper function may throw
+     * @param <X2> Exception Type the notFirstMapper function may throw
+     * @param <R> The element type of the new stream element
+     * @param firstMapper a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function to apply to the first element
+     * @param notFirstMapper a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function to apply to all elements except the first one.
+     * @return the new stream
+     * @throws X1 Exception that firstMapper function may throw
+     * @throws X2 Exception that notFirstMapper function may throw
+     */
     public <X1 extends Throwable, X2 extends Throwable, R> StreamEx<R> mapFirstOrElseThrowing(ThrowableFunction1_1<X1, ? super T, ? extends R> firstMapper, ThrowableFunction1_1<X2, ? super T, ? extends R> notFirstMapper) throws X1, X2 {
         return tryMapFirstOrElse(firstMapper, notFirstMapper);
     }
+    /**
+     * Equivalent to {@link #mapFirstOrElseThrowing(ThrowableFunction1_1, ThrowableFunction1_1)} but hides the exception that
+     * mappers function may throw
+     * @param <R> The element type of the new stream element
+     * @param firstMapper a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function to apply to the first element
+     * @param notFirstMapper a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function to apply to all elements except the first one.
+     * @return the new stream
+     */
     public <R> StreamEx<R> tryMapFirstOrElse(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends R> firstMapper, ThrowableFunction1_1<? extends Throwable, ? super T, ? extends R> notFirstMapper) {
         return mapFirstOrElse(toFunctionSneakyThrowing(firstMapper), toFunctionSneakyThrowing(notFirstMapper));
     }
@@ -340,9 +470,31 @@ public final class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
     public StreamEx<T> mapLast(Function<? super T, ? extends T> mapper) {
         return supply(new PairSpliterator.PSOfRef<>(mapper, spliterator(), false));
     }
+
+    /**
+     * Equivalent to {@link #mapLast(Function)} but accepts Throwable Functions instead and declares exception
+     * may mapper function throw
+     * @param <X> Exception Type mapper function may throw
+     * @param mapper a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function to apply to the last element
+     * @return the new stream
+     * @throws X Exception mapper function may throw
+     */
     public <X extends Throwable> StreamEx<T> mapLastThrowing(ThrowableFunction1_1<X, ? super T, ? extends T> mapper) throws X {
         return tryMapLast(mapper);
     }
+
+    /**
+     * Equivalent to {@link #mapLastThrowing(ThrowableFunction1_1)} but hides the exception that
+     * mapper function may throw
+     * @param mapper a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function to apply to the last element
+     * @return the new stream
+     */
     public StreamEx<T> tryMapLast(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends T> mapper) {
         return mapLast(toFunctionSneakyThrowing(mapper));
     }
@@ -373,11 +525,46 @@ public final class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
             Function<? super T, ? extends R> lastMapper) {
         return new StreamEx<>(new PairSpliterator.PSOfRef<>(lastMapper, notLastMapper, spliterator(), false), context);
     }
-    public <X1 extends Throwable, X2 extends Throwable, R> StreamEx<R> mapLastOrElseThrowing(ThrowableFunction1_1<X1, ? super T, ? extends R> firstMapper, ThrowableFunction1_1<X2, ? super T, ? extends R> notFirstMapper) throws X1, X2 {
-        return tryMapLastOrElse(firstMapper, notFirstMapper);
+
+    /**
+     * Equivalent to {@link #mapLastOrElse(Function, Function)} but accepts Throwable Functions instead and declares exception
+     * may mappers functions throw
+     *
+     * @param <X1> Exception Type the notLastMapper function may throw
+     * @param <X2> Exception Type the lastMapper function may throw
+     * @param <R> The element type of the new stream element
+     * @param notLastMapper a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function to apply to the first element
+     * @param lastMapper a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function to apply to all elements except the first one.
+     * @return the new stream
+     * @throws X1 Exception that notLastMapper function may throw
+     * @throws X2 Exception that lastMapper function may throw
+     */
+    public <X1 extends Throwable, X2 extends Throwable, R> StreamEx<R> mapLastOrElseThrowing(ThrowableFunction1_1<X1, ? super T, ? extends R> notLastMapper, ThrowableFunction1_1<X2, ? super T, ? extends R> lastMapper) throws X1, X2 {
+        return tryMapLastOrElse(notLastMapper, lastMapper);
     }
-    public <R> StreamEx<R> tryMapLastOrElse(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends R> firstMapper, ThrowableFunction1_1<? extends Throwable, ? super T, ? extends R> notFirstMapper) {
-        return mapLastOrElse(toFunctionSneakyThrowing(firstMapper), toFunctionSneakyThrowing(notFirstMapper));
+
+    /**
+     * Equivalent to {@link #mapLastOrElseThrowing(ThrowableFunction1_1, ThrowableFunction1_1)} but hides the exception that
+     * mappers functions may throw
+     * @param <R> The element type of the new stream element
+     * @param notLastMapper a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function to apply to the first element
+     * @param lastMapper a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        function to apply to all elements except the first one.
+     * @return the new stream
+     */
+    public <R> StreamEx<R> tryMapLastOrElse(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends R> notLastMapper, ThrowableFunction1_1<? extends Throwable, ? super T, ? extends R> lastMapper) {
+        return mapLastOrElse(toFunctionSneakyThrowing(notLastMapper), toFunctionSneakyThrowing(lastMapper));
     }
 
     /**
@@ -476,9 +663,37 @@ public final class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
             return s == null ? null : s.entrySet().stream();
         }), context);
     }
+
+    /**
+     * Equivalent to {@link #flatMapToEntry(Function)} but accepts Throwable Functions instead and declares exception
+     * may mapper function throw
+     * @param <X> Exception Type mapper function may throw
+     * @param <K> the type of {@code Map} keys.
+     * @param <V> the type of {@code Map} values.
+     * @param mapper a non-interfering, stateless function to apply to each
+     *        element which produces a {@link Map} of the entries corresponding
+     *        to the single element of the current stream. The mapper function
+     *        may return null or empty {@code Map} if no mapping should
+     *        correspond to some element.
+     * @return the new {@code EntryStream}
+     * @throws X Exception mapper function may throw
+     */
     public <X extends Throwable, K, V> EntryStream<K, V> flatMapToEntryThrowing(ThrowableFunction1_1<X, ? super T, ? extends Map<K, V>> mapper) throws X {
         return tryFlatMapToEntry(mapper);
     }
+
+    /**
+     * Equivalent to {@link #flatMapThrowing(ThrowableFunction1_1)} but hides the exception that
+     * mapper function may throw
+     * @param <K> the type of {@code Map} keys.
+     * @param <V> the type of {@code Map} values.
+     * @param mapper a non-interfering, stateless function to apply to each
+     *        element which produces a {@link Map} of the entries corresponding
+     *        to the single element of the current stream. The mapper function
+     *        may return null or empty {@code Map} if no mapping should
+     *        correspond to some element.
+     * @return the new {@code EntryStream}
+     */
     public  <K, V> EntryStream<K, V> tryFlatMapToEntry(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends Map<K, V>> mapper) {
         return flatMapToEntry(toFunctionSneakyThrowing(mapper));
     }
@@ -564,9 +779,31 @@ public final class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
     public <V> EntryStream<T, V> cross(Function<? super T, ? extends Stream<? extends V>> mapper) {
         return new EntryStream<>(stream().flatMap(a -> EntryStream.withKey(a, mapper.apply(a))), context);
     }
+
+    /**
+     * Equivalent to {@link #cross(Function)} but accepts Throwable Functions instead and declares exception
+     * may accumulator function throw
+     * @param <X> Exception Type the mapper function may throw
+     * @param <V> the type of values.
+     * @param mapper a non-interfering, stateless function to apply to each
+     *        element which produces a stream of the values corresponding to the
+     *        single element of the current stream.
+     * @return the new {@code EntryStream}
+     * @throws X Exception that accumulator function may throw
+     */
     public <X extends Throwable, V> EntryStream<T, V> crossThrowing(ThrowableFunction1_1<X, ? super T, ? extends Stream<? extends V>> mapper) throws X {
         return tryCross(mapper);
     }
+
+    /**
+     * Equivalent to {@link #crossThrowing(ThrowableFunction1_1)} but hides the exception that
+     * accumulator function may throw
+     * @param <V> the type of values.
+     * @param mapper a non-interfering, stateless function to apply to each
+     *        element which produces a stream of the values corresponding to the
+     *        single element of the current stream.
+     * @return the new {@code EntryStream}
+     */
     public  <V> EntryStream<T, V> tryCross(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends Stream<? extends V>> mapper) {
         return cross(toFunctionSneakyThrowing(mapper));
     }
@@ -596,12 +833,29 @@ public final class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
     public <K> Map<K, List<T>> groupingBy(Function<? super T, ? extends K> classifier) {
         return groupingBy(classifier, Collectors.toList());
     }
+    /**
+     * Equivalent to {@link #groupingBy(Function)} but accepts Throwable Functions instead and declares exception
+     * may accumulator function throw
+     * @param <X> Exception Type the mapper function may throw
+     * @param <K> the type of the keys
+     * @param classifier the classifier function mapping input elements to keys
+     * @return a {@code Map} containing the results of the group-by operation
+     * @throws X Exception that accumulator function may throw
+     */
     public <X extends Throwable, K> Map<K, List<T>> groupingByThrowing(ThrowableFunction1_1<X, ? super T, ? extends K> classifier) throws X {
         return tryGroupingBy(classifier);
     }
+    /**
+     * Equivalent to {@link #groupingByThrowing(ThrowableFunction1_1)} but hides the exception that
+     * accumulator function may throw
+     * @param <K> the type of the keys
+     * @param classifier the classifier function mapping input elements to keys
+     * @return a {@code Map} containing the results of the group-by operation
+     */
     public  <K> Map<K, List<T>> tryGroupingBy(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends K> classifier) {
         return groupingBy(toFunctionSneakyThrowing(classifier));
     }
+
     /**
      * Returns a {@code Map} whose keys are the values resulting from applying
      * the classification function to the input elements, and whose

--- a/src/main/java/one/util/streamex/StreamEx.java
+++ b/src/main/java/one/util/streamex/StreamEx.java
@@ -15,6 +15,9 @@
  */
 package one.util.streamex;
 
+import one.util.functionex.ThrowableFunction1_1;
+import one.util.functionex.ThrowableFunction1_2;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
@@ -62,6 +65,7 @@ import java.util.stream.Collector.Characteristics;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static one.util.streamex.InternalUtilities.*;
 import static one.util.streamex.Internals.Box;
 import static one.util.streamex.Internals.ObjLongBox;
 import static one.util.streamex.Internals.PairBox;
@@ -204,8 +208,24 @@ public final class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
      *        element
      * @return the new stream
      */
-    public <V> EntryStream<T, V> mapToEntry(Function<? super T, ? extends V> valueMapper) {
+    public <V> EntryStream<T, V> mapNewValue(Function<? super T, ? extends V> valueMapper) {
         return new EntryStream<>(stream().map(e -> new SimpleImmutableEntry<>(e, valueMapper.apply(e))), context);
+    }
+    public <X extends Throwable, V> EntryStream<T, V> mapNewValueThrowing(ThrowableFunction1_1<X, ? super T, ? extends V> valueMapper) throws X {
+        return tryMapNewValue(valueMapper);
+    }
+    public <V> EntryStream<T, V> tryMapNewValue(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends V> valueMapper) {
+        return mapNewValue(toFunctionSneakyThrowing(valueMapper));
+    }
+
+    public <U, V> EntryStream<U, V> mapToEntry(Function<? super T, ? extends Entry<U, V>> entryMapper) {
+        return new EntryStream<>(stream().map(entryMapper), context);
+    }
+    public <X extends Throwable, U, V> EntryStream<U, V> mapToEntryThrowing(ThrowableFunction1_2<X, ? super T, ? extends U, ? extends V> entryMapper) throws X {
+        return tryMapToEntry(entryMapper);
+    }
+    public <U, V> EntryStream<U, V> tryMapToEntry(ThrowableFunction1_2<? extends Throwable, ? super T, ? extends U, ? extends V> entryMapper) {
+        return mapToEntry(toEntryFunctionSneakyThrowing(entryMapper));
     }
 
     /**
@@ -230,6 +250,14 @@ public final class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
         return new EntryStream<>(stream()
                 .map(e -> new SimpleImmutableEntry<>(keyMapper.apply(e), valueMapper.apply(e))), context);
     }
+    public <X1 extends Throwable, X2 extends Throwable, K, V> EntryStream<K, V> mapToEntryThrowing(ThrowableFunction1_1<X1, ? super T, ? extends K> keyMapper,
+            ThrowableFunction1_1<X2, ? super T, ? extends V> valueMapper) throws X1, X2{
+        return tryMapToEntry(keyMapper, valueMapper);
+    }
+    public <K, V> EntryStream<K, V> tryMapToEntry(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends K> keyMapper,
+            ThrowableFunction1_1<? extends Throwable, ? super T, ? extends V> valueMapper) {
+        return mapToEntry(toFunctionSneakyThrowing(keyMapper), toFunctionSneakyThrowing(valueMapper));
+    }
 
     /**
      * Returns a stream where the first element is the replaced with the result
@@ -249,6 +277,12 @@ public final class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
      */
     public StreamEx<T> mapFirst(Function<? super T, ? extends T> mapper) {
         return supply(new PairSpliterator.PSOfRef<>(mapper, spliterator(), true));
+    }
+    public <X extends Throwable> StreamEx<T> mapFirstThrowing(ThrowableFunction1_1<X, ? super T, ? extends T> mapper) throws X{
+        return tryMapFirst(mapper);
+    }
+    public StreamEx<T> tryMapFirst(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends T> mapper) {
+        return mapFirst(toFunctionSneakyThrowing(mapper));
     }
 
     /**
@@ -277,6 +311,12 @@ public final class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
             Function<? super T, ? extends R> notFirstMapper) {
         return new StreamEx<>(new PairSpliterator.PSOfRef<>(firstMapper, notFirstMapper, spliterator(), true), context);
     }
+    public <X1 extends Throwable, X2 extends Throwable, R> StreamEx<R> mapFirstOrElseThrowing(ThrowableFunction1_1<X1, ? super T, ? extends R> firstMapper, ThrowableFunction1_1<X2, ? super T, ? extends R> notFirstMapper) throws X1, X2 {
+        return tryMapFirstOrElse(firstMapper, notFirstMapper);
+    }
+    public <R> StreamEx<R> tryMapFirstOrElse(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends R> firstMapper, ThrowableFunction1_1<? extends Throwable, ? super T, ? extends R> notFirstMapper) {
+        return mapFirstOrElse(toFunctionSneakyThrowing(firstMapper), toFunctionSneakyThrowing(notFirstMapper));
+    }
 
     /**
      * Returns a stream where the last element is the replaced with the result
@@ -299,6 +339,12 @@ public final class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
      */
     public StreamEx<T> mapLast(Function<? super T, ? extends T> mapper) {
         return supply(new PairSpliterator.PSOfRef<>(mapper, spliterator(), false));
+    }
+    public <X extends Throwable> StreamEx<T> mapLastThrowing(ThrowableFunction1_1<X, ? super T, ? extends T> mapper) throws X {
+        return tryMapLast(mapper);
+    }
+    public StreamEx<T> tryMapLast(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends T> mapper) {
+        return mapLast(toFunctionSneakyThrowing(mapper));
     }
 
     /**
@@ -326,6 +372,12 @@ public final class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
     public <R> StreamEx<R> mapLastOrElse(Function<? super T, ? extends R> notLastMapper,
             Function<? super T, ? extends R> lastMapper) {
         return new StreamEx<>(new PairSpliterator.PSOfRef<>(lastMapper, notLastMapper, spliterator(), false), context);
+    }
+    public <X1 extends Throwable, X2 extends Throwable, R> StreamEx<R> mapLastOrElseThrowing(ThrowableFunction1_1<X1, ? super T, ? extends R> firstMapper, ThrowableFunction1_1<X2, ? super T, ? extends R> notFirstMapper) throws X1, X2 {
+        return tryMapLastOrElse(firstMapper, notFirstMapper);
+    }
+    public <R> StreamEx<R> tryMapLastOrElse(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends R> firstMapper, ThrowableFunction1_1<? extends Throwable, ? super T, ? extends R> notFirstMapper) {
+        return mapLastOrElse(toFunctionSneakyThrowing(firstMapper), toFunctionSneakyThrowing(notFirstMapper));
     }
 
     /**
@@ -424,6 +476,12 @@ public final class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
             return s == null ? null : s.entrySet().stream();
         }), context);
     }
+    public <X extends Throwable, K, V> EntryStream<K, V> flatMapToEntryThrowing(ThrowableFunction1_1<X, ? super T, ? extends Map<K, V>> mapper) throws X {
+        return tryFlatMapToEntry(mapper);
+    }
+    public  <K, V> EntryStream<K, V> tryFlatMapToEntry(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends Map<K, V>> mapper) {
+        return flatMapToEntry(toFunctionSneakyThrowing(mapper));
+    }
 
     /**
      * Performs a cross product of current stream with specified array of
@@ -455,7 +513,7 @@ public final class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
         if (other.length == 0)
             return new EntryStream<>(Spliterators.emptySpliterator(), context);
         if (other.length == 1)
-            return mapToEntry(e -> other[0]);
+            return mapNewValue(e -> other[0]);
         return cross(t -> of(other));
     }
 
@@ -506,6 +564,12 @@ public final class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
     public <V> EntryStream<T, V> cross(Function<? super T, ? extends Stream<? extends V>> mapper) {
         return new EntryStream<>(stream().flatMap(a -> EntryStream.withKey(a, mapper.apply(a))), context);
     }
+    public <X extends Throwable, V> EntryStream<T, V> crossThrowing(ThrowableFunction1_1<X, ? super T, ? extends Stream<? extends V>> mapper) throws X {
+        return tryCross(mapper);
+    }
+    public  <V> EntryStream<T, V> tryCross(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends Stream<? extends V>> mapper) {
+        return cross(toFunctionSneakyThrowing(mapper));
+    }
 
     /**
      * Returns a {@code Map} whose keys are the values resulting from applying
@@ -532,7 +596,12 @@ public final class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
     public <K> Map<K, List<T>> groupingBy(Function<? super T, ? extends K> classifier) {
         return groupingBy(classifier, Collectors.toList());
     }
-
+    public <X extends Throwable, K> Map<K, List<T>> groupingByThrowing(ThrowableFunction1_1<X, ? super T, ? extends K> classifier) throws X {
+        return tryGroupingBy(classifier);
+    }
+    public  <K> Map<K, List<T>> tryGroupingBy(ThrowableFunction1_1<? extends Throwable, ? super T, ? extends K> classifier) {
+        return groupingBy(toFunctionSneakyThrowing(classifier));
+    }
     /**
      * Returns a {@code Map} whose keys are the values resulting from applying
      * the classification function to the input elements, and whose

--- a/src/test/java/one/util/functionex/ThrowableFunction0_0Test.java
+++ b/src/test/java/one/util/functionex/ThrowableFunction0_0Test.java
@@ -1,0 +1,84 @@
+package one.util.functionex;
+
+import one.util.functionex.utils.CustomException;
+import org.junit.Test;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static one.util.functionex.Tuple.of;
+import static one.util.functionex.utils.Utils.throwableAction;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class ThrowableFunction0_0Test {
+
+    @Test
+    public void should_compose_new_function_by_adding_runnable_after() throws CustomException {
+        List<String> responses = new ArrayList<>();
+        ThrowableFunction0_0<CustomException> composition = ThrowableFunction0_0
+            .narrow(() -> responses.add(throwableAction("Luke")))
+            .andRun(() -> responses.add(throwableAction("Anakin")));
+        composition.apply();
+        assertEquals(responses, Arrays.asList("Luke", "Anakin"));
+    }
+    @Test
+    public void should_compose_new_function_by_adding_runnable_after_but_raise_exception() {
+        List<String> responses = new ArrayList<>();
+        ThrowableFunction0_0<CustomException> composition = ThrowableFunction0_0
+            .narrow(() -> responses.add(throwableAction("Luke")))
+            .andRun(() -> responses.add(throwableAction("error")));
+        assertThrows(CustomException.class, composition::apply);
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_supplier_after() throws CustomException {
+        List<String> firstnames = new ArrayList<>(Collections.singletonList("Luke"));
+        ThrowableFunction0_1<CustomException, String> composition = ThrowableFunction0_0
+            .narrow(() -> firstnames.add(throwableAction("Anakin")))
+            .andSupply(() -> throwableAction(String.join(", ", firstnames)));
+        String names = composition.apply();
+        assertEquals(names, "Luke, Anakin");
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_entry_supplier_after() throws CustomException {
+        List<String> firstnames = new ArrayList<>(Collections.singletonList("Luke"));
+        ThrowableFunction0_2<CustomException, String, String> composition = ThrowableFunction0_0
+            .narrow(() -> firstnames.add(throwableAction("Anakin")))
+            .andSupplyEntry(() -> of(firstnames.get(0), firstnames.get(1)));
+        Map.Entry<String, String> entry = composition.apply();
+        assertEquals(entry, of("Luke", "Anakin"));
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_runnable_before() throws CustomException {
+        List<String> responses = new ArrayList<>();
+        ThrowableFunction0_0<CustomException> composition = ThrowableFunction0_0
+            .narrow(() -> responses.add(throwableAction("Anakin")))
+            .compose(() -> responses.add(throwableAction("Luke")));
+        composition.apply();
+        assertEquals(responses, Arrays.asList("Luke", "Anakin"));
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_supplier_before() throws CustomException {
+        AtomicInteger value = new AtomicInteger(0);
+        ThrowableFunction1_0<CustomException, Integer> composition = ThrowableFunction0_0
+            .narrow(() -> throwableAction(value.getAndIncrement()))
+            .compose(value::set);
+        composition.apply(5);
+        assertEquals(value.get(), 6);
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_entry_consumer_before() throws CustomException {
+        AtomicInteger value = new AtomicInteger(0);
+        ThrowableFunction2_0<CustomException, Integer, Integer> composition = ThrowableFunction0_0
+            .narrow(() -> throwableAction(value.incrementAndGet()))
+            .compose((i1, i2) -> value.set(i1 + i2));
+        composition.apply(5, 3);
+        assertEquals(value.get(),9);
+    }
+
+}

--- a/src/test/java/one/util/functionex/ThrowableFunction0_1Test.java
+++ b/src/test/java/one/util/functionex/ThrowableFunction0_1Test.java
@@ -1,0 +1,72 @@
+package one.util.functionex;
+
+import one.util.functionex.utils.CustomException;
+import org.junit.Test;
+
+import java.util.*;
+
+import static one.util.functionex.Tuple.of;
+import static one.util.functionex.utils.Utils.throwableAction;
+import static org.junit.Assert.assertEquals;
+
+public class ThrowableFunction0_1Test {
+
+    @Test
+    public void should_compose_new_function_by_adding_consumer_after() throws CustomException {
+        List<String> responses = new ArrayList<>();
+        ThrowableFunction0_0<CustomException> composition = ThrowableFunction0_1
+            .narrow(() -> throwableAction("Luke"))
+            .andConsumes(first -> responses.add(first+" "+throwableAction("Skywalker")));
+        composition.apply();
+        assertEquals(responses, Collections.singletonList("Luke Skywalker"));
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_map_function_after() throws CustomException {
+        ThrowableFunction0_1<CustomException, String> composition = ThrowableFunction0_1
+            .narrow(() -> throwableAction("Luke"))
+            .andMap(first -> first +" Skywalker");
+        String name = composition.apply();
+        assertEquals(name, "Luke Skywalker");
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_map_to_entry_function_after() throws CustomException {
+        String firstname = "Luke";
+        ThrowableFunction0_2<CustomException, String, String> composition = ThrowableFunction0_1
+            .narrow(() -> throwableAction("Skywalker"))
+            .andMapToEntry(name -> of(firstname, name));
+        Map.Entry<String, String> entry = composition.apply();
+        assertEquals(entry, of("Luke", "Skywalker"));
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_supplier_before() throws CustomException {
+        StringBuilder builder = new StringBuilder();
+        ThrowableFunction0_1<CustomException, String> composition = ThrowableFunction0_1
+            .narrow(() -> builder.append(throwableAction(" Skywalker")).toString())
+            .compose(() -> builder.append(throwableAction("Luke")));
+        String result = composition.apply();
+        assertEquals(result, "Luke Skywalker");
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_consumer_before() throws CustomException {
+        StringBuilder builder = new StringBuilder();
+        ThrowableFunction1_1<CustomException, String, String> composition = ThrowableFunction0_1
+            .narrow(() -> builder.append(throwableAction("Skywalker")).toString())
+            .compose(first -> builder.append(first).append(" "));
+        String result = composition.apply("Luke");
+        assertEquals(result, "Luke Skywalker");
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_entry_consumer_before() throws CustomException {
+        StringBuilder builder = new StringBuilder();
+        ThrowableFunction2_1<CustomException, String, String, String> composition = ThrowableFunction0_1
+            .narrow(() -> builder.append(throwableAction("Skywalker")).toString())
+            .compose((first, delimiter) -> builder.append(first).append(delimiter));
+        String result = composition.apply("Luke", " ");
+        assertEquals(result,"Luke Skywalker");
+    }
+}

--- a/src/test/java/one/util/functionex/ThrowableFunction0_2Test.java
+++ b/src/test/java/one/util/functionex/ThrowableFunction0_2Test.java
@@ -1,0 +1,70 @@
+package one.util.functionex;
+
+import one.util.functionex.utils.CustomException;
+import org.junit.Test;
+
+import java.util.AbstractMap;
+import java.util.Map;
+
+import static one.util.functionex.Tuple.of;
+import static one.util.functionex.utils.Utils.throwableAction;
+import static org.junit.Assert.assertEquals;
+
+public class ThrowableFunction0_2Test {
+
+    @Test
+    public void should_compose_new_function_by_adding_consumer_after() throws CustomException {
+        StringBuilder builder = new StringBuilder();
+        ThrowableFunction0_2<CustomException, String, String> function = () -> of(throwableAction("Luke"), "Skywalker");
+        ThrowableFunction0_0<CustomException> composition = function.andConsumes((first, last) -> builder.append(first).append(" ").append(last));
+        composition.apply();
+        assertEquals(builder.toString(), "Luke Skywalker");
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_map_function_after() throws CustomException {
+        ThrowableFunction0_2<CustomException, String, String> function = () -> of(throwableAction("Luke"), "Skywalker");
+        ThrowableFunction0_1<CustomException, String> composition = function.andReduce((first, last) -> first+" "+last);
+        String result = composition.apply();
+        assertEquals(result, "Luke Skywalker");
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_map_to_entry_function_after() throws CustomException {
+        ThrowableFunction0_2<CustomException, String, String> function = () -> of(throwableAction("Luke"), "Skywalker");
+        ThrowableFunction0_2<CustomException, String, Integer> composition = function.andMap((first, last) -> of(first+" "+last, (first+" "+last).length()));
+        Map.Entry<String, Integer> entry = composition.apply();
+        assertEquals(entry.getKey(), "Luke Skywalker");
+        assertEquals(entry.getValue().intValue(), 14);
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_supplier_before() throws CustomException {
+        StringBuilder builder = new StringBuilder();
+        ThrowableFunction0_2<CustomException, String, Integer> function = () -> of(builder.toString(), builder.toString().length());
+        ThrowableFunction0_2<CustomException, String, Integer> composition = function.compose(() -> builder.append("Luke Skywalker"));
+        Map.Entry<String, Integer> entry = composition.apply();
+        assertEquals(entry.getKey(), "Luke Skywalker");
+        assertEquals(entry.getValue().intValue(), 14);
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_consumer_before() throws CustomException {
+        StringBuilder builder = new StringBuilder();
+        ThrowableFunction0_2<CustomException, String, Integer> function = () -> of(builder.toString(), builder.toString().length());
+        ThrowableFunction1_2<CustomException, String, String, Integer> composition = function.compose(builder::append);
+        Map.Entry<String, Integer> entry = composition.apply("Luke Skywalker");
+        assertEquals(entry.getKey(), "Luke Skywalker");
+        assertEquals(entry.getValue().intValue(), 14);
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_entry_consumer_before() throws CustomException {
+        StringBuilder builder = new StringBuilder();
+        ThrowableFunction0_2<CustomException, String, Integer> function = () -> of(builder.toString(), builder.toString().length());
+        ThrowableFunction2_2<CustomException, String, String, String, Integer> composition = function.compose((first, last) -> builder.append(first).append(" ").append(last));
+        Map.Entry<String, Integer> entry = composition.apply("Luke", "Skywalker");
+        assertEquals(entry.getKey(), "Luke Skywalker");
+        assertEquals(entry.getValue().intValue(), 14);
+    }
+}

--- a/src/test/java/one/util/functionex/ThrowableFunction1_0Test.java
+++ b/src/test/java/one/util/functionex/ThrowableFunction1_0Test.java
@@ -1,0 +1,78 @@
+package one.util.functionex;
+
+import one.util.functionex.utils.CustomException;
+import one.util.functionex.utils.Utils;
+import org.junit.Test;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static one.util.functionex.Tuple.of;
+import static one.util.functionex.utils.Utils.throwableAction;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class ThrowableFunction1_0Test {
+
+    @Test
+    public void should_compose_new_function_by_adding_runnable_after() throws CustomException {
+        StringBuilder builder = new StringBuilder();
+        ThrowableFunction1_0<CustomException, String> function = firstname -> builder.append(throwableAction(firstname));
+        ThrowableFunction1_0<CustomException, String> composition = function.andRun(() -> builder.append(" Skywalker"));
+        composition.apply("Luke");
+        assertEquals(builder.toString(), "Luke Skywalker");
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_supplier_after() throws CustomException {
+        StringBuilder builder = new StringBuilder();
+        ThrowableFunction1_0<CustomException, String> function = firstname -> builder.append(throwableAction(firstname));
+        ThrowableFunction1_1<CustomException, String, String> composition = function.andSupply(() -> builder.append(throwableAction(" Skywalker")).toString());
+        String name = composition.apply("Luke");
+        assertEquals(name, "Luke Skywalker");
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_entry_supplier_after() throws CustomException {
+        String name = "Skywalker";
+        List<String> firstnames = new ArrayList<>();
+        ThrowableFunction1_0<CustomException, List<String>> function = list -> list.addAll(asList(throwableAction("Luke"), "Anakin"));
+        ThrowableFunction1_2<CustomException, List<String>, String, String> composition = function.andSupplyEntry(
+            () -> of(firstnames.get(0) + " " + name, firstnames.get(1) + " " + name));
+        Map.Entry<String, String> entry = composition.apply(firstnames);
+        assertEquals(entry, of("Luke Skywalker", "Anakin Skywalker"));
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_supplier_before() throws CustomException {
+        StringBuilder builder = new StringBuilder();
+        ThrowableFunction1_0<CustomException, String> function =
+            firstname -> builder.append(firstname).append(" ").append(throwableAction("Skywalker"));
+        ThrowableFunction0_0<CustomException> composition = function.compose(() -> throwableAction("Luke"));
+        composition.apply();
+        assertEquals(builder.toString(), "Luke Skywalker");
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_function_before() throws CustomException {
+        StringBuilder builder = new StringBuilder();
+        ThrowableFunction1_0<CustomException, String> function =
+            firstname -> builder.append(firstname).append(" ").append(throwableAction("Skywalker"));
+        ThrowableFunction1_0<CustomException, String> composition = function.compose(Utils::throwableAction);
+        composition.apply("Luke");
+        assertEquals(builder.toString(), "Luke Skywalker");
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_bi_function_before() throws CustomException {
+        StringBuilder builder = new StringBuilder();
+        ThrowableFunction1_0<CustomException, String> function = name -> builder.append(throwableAction(name));
+        ThrowableFunction2_0<CustomException, String, String> composition = function.compose((s1, s2) -> s1+" "+s2);
+        composition.apply("Luke", "Skywalker");
+        assertEquals(builder.toString(), "Luke Skywalker");
+    }
+
+}

--- a/src/test/java/one/util/functionex/ThrowableFunction1_1Test.java
+++ b/src/test/java/one/util/functionex/ThrowableFunction1_1Test.java
@@ -1,0 +1,76 @@
+package one.util.functionex;
+
+import one.util.functionex.utils.CustomException;
+import one.util.functionex.utils.Utils;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static one.util.functionex.Tuple.of;
+import static one.util.functionex.utils.Utils.checkNonNegative;
+import static one.util.functionex.utils.Utils.throwableAction;
+import static org.junit.Assert.assertEquals;
+
+public class ThrowableFunction1_1Test {
+
+    @Test
+    public void should_compose_new_function_by_adding_consumer_after() throws CustomException {
+        StringBuilder builder = new StringBuilder();
+        ThrowableFunction1_0<CustomException, String> composition = ThrowableFunction1_1
+            .narrow((String text) -> throwableAction(text).length())
+            .andConsume(length -> builder.append("The text contains ").append(length).append(" characters"));
+        composition.apply("Luke Skywalker is a jedi");
+        assertEquals(builder.toString(), "The text contains 24 characters");
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_mapping_after() throws CustomException {
+        ThrowableFunction1_1<CustomException, String, String> composition = ThrowableFunction1_1
+            .narrow((String text) -> throwableAction(text).length())
+            .andMap(length -> "The text contains "+length+" characters");
+        String result = composition.apply("Luke Skywalker is a jedi");
+        assertEquals(result, "The text contains 24 characters");
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_mapping_entry_after() throws CustomException {
+        ThrowableFunction1_2<CustomException, String, Integer, String> composition = ThrowableFunction1_1
+            .narrow((String text) -> throwableAction(text).length())
+            .andMapToEntry(length -> of(checkNonNegative(length), "The text contains "+length+" characters"));
+        Tuple<Integer, String> result = composition.apply("Luke Skywalker is a jedi");
+        assertEquals(result, of(24, "The text contains 24 characters"));
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_supplier_before() throws CustomException {
+        String input = "Luke Skywalker is a jedi";
+        ThrowableFunction0_1<CustomException, String> composition = ThrowableFunction1_1
+            .narrow((Integer length) -> "The text contains "+checkNonNegative(length)+" characters")
+            .compose(input::length);
+        String result = composition.apply();
+        assertEquals(result, "The text contains 24 characters");
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_function_before() throws CustomException {
+        ThrowableFunction1_1<CustomException, String, String> composition = ThrowableFunction1_1
+            .narrow((Integer length) -> "The text contains "+checkNonNegative(length)+" characters")
+            .compose(String::length);
+        String result = composition.apply("Luke Skywalker is a jedi");
+        assertEquals(result, "The text contains 24 characters");
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_bi_function_before() throws CustomException {
+        ThrowableFunction2_1<CustomException, String, Tuple<String, String>, String> composition = ThrowableFunction1_1
+            .narrow((Integer length) -> "The text contains "+checkNonNegative(length)+" characters")
+            .compose((input, replace) -> input.replaceAll(replace.t1(), replace.t2()).length());
+        String result = composition.apply("Luke Skywalker is a jedi", of(" Skywalker", ""));
+        assertEquals(result, "The text contains 14 characters");
+    }
+
+}

--- a/src/test/java/one/util/functionex/ThrowableFunction1_2Test.java
+++ b/src/test/java/one/util/functionex/ThrowableFunction1_2Test.java
@@ -1,0 +1,70 @@
+package one.util.functionex;
+
+import one.util.functionex.utils.CustomException;
+import one.util.functionex.utils.Utils;
+import org.junit.Test;
+
+import java.util.*;
+
+import static one.util.functionex.Tuple.of;
+import static one.util.functionex.utils.Utils.throwableAction;
+import static org.junit.Assert.assertEquals;
+
+public class ThrowableFunction1_2Test {
+
+    @Test
+    public void should_compose_new_function_by_adding_runnable_after() throws CustomException {
+        StringBuilder builder = new StringBuilder();
+        ThrowableFunction1_2<CustomException, String, String, Integer> function = text -> of(text, text.length());
+        ThrowableFunction1_0<CustomException, String> composition = function.andConsume((text, length) -> builder.append(text).append(":").append(length));
+        composition.apply("Luke Skywalker is a jedi");
+        assertEquals(builder.toString(), "Luke Skywalker is a jedi:24");
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_supplier_after() throws CustomException {
+        ThrowableFunction1_2<CustomException, String, String, Integer> function = text -> of(text, text.length());
+        ThrowableFunction1_1<CustomException, String, String> composition = function.andReduce((text, length) -> throwableAction(text+":"+length));
+        String result = composition.apply("Luke Skywalker is a jedi");
+        assertEquals(result, "Luke Skywalker is a jedi:24");
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_entry_supplier_after() throws CustomException {
+        String name = "Skywalker";
+        List<String> firstnames = new ArrayList<>();
+        ThrowableFunction1_2<CustomException, String, String, Integer> function = text -> of(text, text.length());
+        ThrowableFunction1_2<CustomException, String, String, Integer> composition = function.andMap(
+            (text, length) -> of(throwableAction(text), length));
+        Tuple<String, Integer> entry = composition.apply("Luke Skywalker is a jedi");
+        assertEquals(entry, of("Luke Skywalker is a jedi", 24));
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_supplier_before() throws CustomException {
+        ThrowableFunction1_2<CustomException, String, String, Integer> function =
+            text -> of(text, text.length());
+        ThrowableFunction0_2<CustomException, String, Integer> composition = function.compose(() -> throwableAction("Luke Skywalker is a jedi"));
+        Map.Entry<String, Integer> entry = composition.apply();
+        assertEquals(entry, of("Luke Skywalker is a jedi", 24));
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_function_before() throws CustomException {
+        ThrowableFunction1_2<CustomException, String, String, Integer> function =
+            text -> of(text, text.length());
+        ThrowableFunction1_2<CustomException, String, String, Integer> composition = function.compose(Utils::throwableAction);
+        Map.Entry<String, Integer> entry = composition.apply("Luke Skywalker is a jedi");
+        assertEquals(entry, of("Luke Skywalker is a jedi", 24));
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_bi_function_before() throws CustomException {
+        ThrowableFunction1_2<CustomException, String, String, Integer> function =
+            text -> of(text, text.length());
+        ThrowableFunction2_2<CustomException, String, String, String, Integer> composition = function.compose((name, text) -> throwableAction(name)+" "+text);
+        Map.Entry<String, Integer> entry = composition.apply("Luke Skywalker", "is a jedi");
+        assertEquals(entry, of("Luke Skywalker is a jedi", 24));
+    }
+
+}

--- a/src/test/java/one/util/functionex/ThrowableFunction2_0Test.java
+++ b/src/test/java/one/util/functionex/ThrowableFunction2_0Test.java
@@ -1,0 +1,84 @@
+package one.util.functionex;
+
+import one.util.functionex.utils.CustomException;
+import one.util.functionex.utils.Utils;
+import one.util.streamex.StreamEx;
+import org.junit.Test;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static one.util.functionex.Tuple.of;
+import static one.util.functionex.utils.Utils.throwableAction;
+import static org.junit.Assert.assertEquals;
+
+public class ThrowableFunction2_0Test {
+
+    @Test
+    public void should_compose_new_function_by_adding_runnable_after() throws CustomException {
+        StringBuilder builder = new StringBuilder();
+        ThrowableFunction2_0<CustomException, String, String> function = (firstname, lastname) -> builder.append(throwableAction(firstname+ " "+ lastname));
+        ThrowableFunction2_0<CustomException, String, String> composition = function.andRun(() -> builder.append(" is a jedi."));
+        composition.apply("Luke", "Skywalker");
+        assertEquals(builder.toString(), "Luke Skywalker is a jedi.");
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_supplier_after() throws CustomException {
+        String name = "Skywalker";
+        List<String> firstnames = new ArrayList<>();
+        ThrowableFunction2_0<CustomException, String, String> function = (name1, name2) -> firstnames.addAll(asList(throwableAction(name1), name2));
+        ThrowableFunction2_1<CustomException, String, String, List<String>> composition = function.andSupply(
+            () -> StreamEx.of(firstnames).mapThrowing(first -> throwableAction(first + " " + name)).toList());
+        List<String> names = composition.apply("Luke", "Anakin");
+        assertEquals(names, asList("Luke Skywalker", "Anakin Skywalker"));
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_entry_supplier_after() throws CustomException {
+        String name = "Skywalker";
+        List<String> firstnames = new ArrayList<>();
+        ThrowableFunction2_0<CustomException, String, String> function = (name1, name2) -> firstnames.addAll(asList(throwableAction(name1), name2));
+        ThrowableFunction2_2<CustomException, String, String, String, String> composition = function.andSupplyEntry(
+            () -> of(firstnames.get(0)+" "+name, firstnames.get(1)+" "+name));
+        Map.Entry<String, String> entry = composition.apply("Luke", "Anakin");
+        assertEquals(entry, of("Luke Skywalker", "Anakin Skywalker"));
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_supplier_before() throws CustomException {
+        StringBuilder builder = new StringBuilder();
+        ThrowableFunction2_0<CustomException, String, String> function =
+            (firstname, lastname) -> builder.append(firstname).append(" ").append(throwableAction(lastname));
+        ThrowableFunction0_0<CustomException> composition = function.compose(
+            () -> of(throwableAction("Luke"), "Skywalker"));
+        composition.apply();
+        assertEquals(builder.toString(), "Luke Skywalker");
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_function_before() throws CustomException {
+        StringBuilder builder = new StringBuilder();
+        ThrowableFunction2_0<CustomException, String, String> function =
+            (firstname, lastname) -> builder.append(firstname).append(" ").append(throwableAction(lastname));
+        ThrowableFunction1_0<CustomException, String> composition = function.compose(
+            firstname -> of(throwableAction(firstname), "Skywalker"));
+        composition.apply("Luke");
+        assertEquals(builder.toString(), "Luke Skywalker");
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_bi_function_before() throws CustomException {
+        StringBuilder builder = new StringBuilder();
+        ThrowableFunction2_0<CustomException, String, String> function =
+            (firstname, lastname) -> builder.append(firstname).append(" ").append(throwableAction(lastname));
+        ThrowableFunction2_0<CustomException, String, String> composition = function.compose(
+            (firstname, lastname) -> of(throwableAction(firstname), lastname));
+        composition.apply("Luke", "Skywalker");
+        assertEquals(builder.toString(), "Luke Skywalker");
+    }
+
+}

--- a/src/test/java/one/util/functionex/ThrowableFunction2_1Test.java
+++ b/src/test/java/one/util/functionex/ThrowableFunction2_1Test.java
@@ -1,0 +1,65 @@
+package one.util.functionex;
+
+import one.util.functionex.utils.CustomException;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static one.util.functionex.Tuple.of;
+import static one.util.functionex.utils.Utils.checkNonNegative;
+import static org.junit.Assert.assertEquals;
+
+public class ThrowableFunction2_1Test {
+
+    @Test
+    public void should_compose_new_function_by_adding_runnable_after() throws CustomException {
+        AtomicInteger result = new AtomicInteger();
+        ThrowableFunction2_0<CustomException, Integer, Integer> composition = ThrowableFunction2_1
+            .narrow((Integer width, Integer height) -> checkNonNegative(2*(width+height)))
+            .andConsume(perimeter -> result.set(perimeter*perimeter));
+        composition.apply(5, 3);
+        assertEquals(256, result.get());
+    }
+
+    @Test
+    public void should_compose_new_function_by_mapping_after() throws CustomException {
+        ThrowableFunction2_1<CustomException, Integer, Integer, Integer> composition = ThrowableFunction2_1
+            .narrow((Integer width, Integer height) -> checkNonNegative(2*(width+height)))
+            .andMap(perimeter -> perimeter*perimeter);
+        assertEquals(256, composition.apply(5, 3).intValue());
+    }
+
+    @Test
+    public void should_compose_new_function_by_mapping_entry_after() throws CustomException {
+        ThrowableFunction2_2<CustomException, Integer, Integer, Integer, Double> composition = ThrowableFunction2_1
+            .narrow((Integer width, Integer height) -> checkNonNegative(2*(width+height)))
+            .andMapToEntry(perimeter -> of(perimeter*perimeter, Math.sqrt(perimeter)));
+        assertEquals(of(256, 4.0), composition.apply(5, 3));
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_supplier_entry_before() throws CustomException {
+        Tuple<Integer, Integer> input = of(5, 3);
+        ThrowableFunction0_1<CustomException, Integer> composition = ThrowableFunction2_1
+            .narrow((Integer v1, Integer v2) -> checkNonNegative(v1)-v2)
+            .compose(() -> of(input.t1()* input.t1(), input.t2()*input.t2()));
+        assertEquals(16, composition.apply().intValue());
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_function_before() throws CustomException {
+        ThrowableFunction1_1<CustomException, Tuple<Integer, Integer>, Integer> composition = ThrowableFunction2_1
+            .narrow((Integer v1, Integer v2) -> checkNonNegative(v1)-v2)
+            .compose(input -> of(input.t1()* input.t1(), input.t2()*input.t2()));
+        assertEquals(16, composition.apply(of(5,3)).intValue());
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_bi_function_before() throws CustomException {
+        ThrowableFunction2_1<CustomException, Integer, Integer, Integer> composition = ThrowableFunction2_1
+            .narrow((Integer v1, Integer v2) -> checkNonNegative(v1)-v2)
+            .compose((v1, v2) -> of(v1*v1, v2*v2));
+        assertEquals(16, composition.apply(5,3).intValue());
+    }
+
+}

--- a/src/test/java/one/util/functionex/ThrowableFunction2_2Test.java
+++ b/src/test/java/one/util/functionex/ThrowableFunction2_2Test.java
@@ -1,0 +1,72 @@
+package one.util.functionex;
+
+import one.util.functionex.utils.CustomException;
+import one.util.streamex.StreamEx;
+import org.junit.Test;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.Arrays.asList;
+import static one.util.functionex.Tuple.of;
+import static one.util.functionex.utils.Utils.checkNonNegative;
+import static one.util.functionex.utils.Utils.throwableAction;
+import static org.junit.Assert.assertEquals;
+
+public class ThrowableFunction2_2Test {
+
+    @Test
+    public void should_compose_new_function_by_adding_runnable_after() throws CustomException {
+        AtomicInteger result = new AtomicInteger();
+        ThrowableFunction2_0<CustomException, Integer, Integer> composition = ThrowableFunction2_2
+            .narrow((Integer v1, Integer v2) -> of(checkNonNegative(v1+v2), v1-v2))
+            .andConsume((addition, conjugate) -> result.set(addition * conjugate));
+        composition.apply(5, 3);
+        assertEquals(16, result.get());
+    }
+
+    @Test
+    public void should_compose_new_function_by_reducing_after() throws CustomException {
+        ThrowableFunction2_1<CustomException, Integer, Integer, Integer> composition = ThrowableFunction2_2
+            .narrow((Integer v1, Integer v2) -> of(checkNonNegative(v1+v2), v1-v2))
+            .andReduce((addition, conjugate) -> addition * conjugate);
+        assertEquals(16, composition.apply(5, 3).intValue());
+    }
+
+    @Test
+    public void should_compose_new_function_by_mapping_entry_after() throws CustomException {
+        ThrowableFunction2_2<CustomException, Integer, Integer, Integer, Integer> composition = ThrowableFunction2_2
+            .narrow((Integer v1, Integer v2) -> of(checkNonNegative(v1+v2), v1-v2))
+            .andMap((addition, conjugate) -> of(addition * conjugate, addition/conjugate));
+        assertEquals(of(16,4), composition.apply(5, 3));
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_supplier_entry_before() throws CustomException {
+        Tuple<Integer, Integer> input = of(5, 3);
+        ThrowableFunction0_2<CustomException, Integer, Integer> composition = ThrowableFunction2_2
+            .narrow((Integer v1, Integer v2) -> of(checkNonNegative(v1+v2), v1-v2))
+            .compose(() -> of(input.t1()* input.t1(), input.t2()*input.t2()));
+        assertEquals(of(34,16), composition.apply());
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_function_before() throws CustomException {
+        ThrowableFunction1_2<CustomException, Tuple<Integer, Integer>, Integer, Integer> composition = ThrowableFunction2_2
+            .narrow((Integer v1, Integer v2) -> of(checkNonNegative(v1+v2), v1-v2))
+            .compose(input -> of(input.t1()* input.t1(), input.t2()*input.t2()));
+        assertEquals(of(34,16), composition.apply(of(5,3)));
+    }
+
+    @Test
+    public void should_compose_new_function_by_adding_bi_function_before() throws CustomException {
+        ThrowableFunction2_2<CustomException, Integer, Integer, Integer, Integer> composition = ThrowableFunction2_2
+            .narrow((Integer v1, Integer v2) -> of(checkNonNegative(v1+v2), v1-v2))
+            .compose((v1, v2) -> of(v1*v1, v2*v2));
+        assertEquals(of(34,16), composition.apply(5,3));
+    }
+
+}

--- a/src/test/java/one/util/functionex/utils/CustomException.java
+++ b/src/test/java/one/util/functionex/utils/CustomException.java
@@ -1,0 +1,7 @@
+package one.util.functionex.utils;
+
+public class CustomException extends Exception {
+    CustomException(String message) {
+            super(message);
+        }
+}

--- a/src/test/java/one/util/functionex/utils/Utils.java
+++ b/src/test/java/one/util/functionex/utils/Utils.java
@@ -1,0 +1,21 @@
+package one.util.functionex.utils;
+
+public class Utils {
+
+    public static String throwableAction(String value) throws CustomException {
+        if(value.contains("error"))
+            throw new CustomException(value);
+        return value;
+    }
+    public static String throwableAction(int value) throws CustomException {
+        if(value < 0)
+            throw new CustomException(String.valueOf(value));
+        return String.valueOf(value);
+    }
+    public static int checkNonNegative(int value) throws CustomException {
+        if(value < 0)
+            throw new CustomException(String.valueOf(value));
+        return value;
+    }
+
+}

--- a/src/test/java/one/util/streamex/StreamExInternalTest.java
+++ b/src/test/java/one/util/streamex/StreamExInternalTest.java
@@ -82,7 +82,13 @@ public class StreamExInternalTest {
     }
 
     /*
-
+        In this example, we can see that I don't need to catch the exception in the method mapThrowing.
+        This method accepts throwable functions.
+        But this method detects automatically the exception that can be thrown and I have to manage the DomainException
+        outside of the stream.
+        Here, we have to add the throws declaration in testMapThrowingMethod. If you remove it, an error of compilation
+        will appear in mapThrowing method asking to handle DomainException.
+        The goal is to keep the possibility to throw important Domain exception that should not be hidden.
      */
     @Test
     public void testMapThrowing() throws DomainException {
@@ -95,6 +101,14 @@ public class StreamExInternalTest {
         assertEquals("map throwing", asList("Luke Skywalker", "Leïa Skywalker", "Anakin Skywalker"), result);
     }
 
+    /*
+        In this example, we can see that I don't need to catch the exception in the method mapThrowing too because this
+        method accepts throwable functions too.
+        But this method hides exceptions that could be thrown (even not RuntimeException) and you can see there is not
+        the throws declaration like the mapThrowing.
+        If this exception occurs, it will be thrown the same in a sneaky way.
+        This method reacts is exactly the same as the map function except that it accepts throwable functions too.
+     */
     @Test
     public void testTryMap() {
         List<String> result = StreamEx.of("Luke", "Leïa", "Anakin")
@@ -103,6 +117,28 @@ public class StreamExInternalTest {
                     throw new DomainException();
                 return firstname + " Skywalker";
             }).toList();
+        assertEquals("map throwing", asList("Luke Skywalker", "Leïa Skywalker", "Anakin Skywalker"), result);
+    }
+
+    /*
+        In this example, i want to throw only important domain exceptions and maybe handling other technical exceptions
+        in a different way.
+        If I use mapThrowing, the exception that i have to declare is Exception because it is the exception parent in
+        common between DomainException and ClassNotFoundException.
+        But i want to declare to throw only DomainException, then i can do this : I use the tryMap to hide all exceptions
+        and i add a method throwing that just declares exception that i want to throw.
+     */
+    @Test
+    public void testTryMapWithSpecificThrowing() throws DomainException {
+        List<String> result = StreamEx.of("Luke", "Leïa", "Anakin")
+            .tryMap(firstname -> {
+                if (firstname.equals("Error"))
+                    throw new DomainException();
+                if (firstname.equals("Class"))
+                    throw new ClassNotFoundException();
+                return firstname + " Skywalker";
+            }).throwing(DomainException.class)
+            .toList();
         assertEquals("map throwing", asList("Luke Skywalker", "Leïa Skywalker", "Anakin Skywalker"), result);
     }
 

--- a/src/test/java/one/util/streamex/TestHelpers.java
+++ b/src/test/java/one/util/streamex/TestHelpers.java
@@ -397,7 +397,7 @@ public class TestHelpers {
                 }
                 List<Integer> order = IntStreamEx.ofIndices(spliterators).boxed().toMutableList();
                 Collections.shuffle(order, r);
-                List<T> list = StreamEx.of(order).mapToEntry(idx -> {
+                List<T> list = StreamEx.of(order).mapNewValue(idx -> {
                     Spliterator<T> s = spliterators.get(idx);
                     Stream.Builder<T> builder = Stream.builder();
                     s.forEachRemaining(builder);

--- a/src/test/java/one/util/streamex/TreeSpliteratorTest.java
+++ b/src/test/java/one/util/streamex/TreeSpliteratorTest.java
@@ -41,7 +41,7 @@ public class TreeSpliteratorTest {
     @Test
     public void testDepthSpliterator() {
         List<Entry<Integer, String>> expected = StreamEx.of("", "a", "aa", "ab", "ac", "b", "ba", "bb", "bc", "c", "ca",
-            "cb", "cc").mapToEntry(String::length).invert().toList();
+            "cb", "cc").mapNewValue(String::length).invert().toList();
         checkSpliterator("tree", expected, () -> new TreeSpliterator.Depth<>("", (depth, s) -> depth == 2 ? null
                 : Stream.of("a", "b", "c").map(s::concat), 0));
     }

--- a/src/test/java/one/util/streamex/api/BaseStreamExTest.java
+++ b/src/test/java/one/util/streamex/api/BaseStreamExTest.java
@@ -99,7 +99,7 @@ public class BaseStreamExTest {
             .onClose(ex.apply("StreamEx"))
             .map(x -> x * 2)
             .onClose(() -> flag.set(true))
-            .pairMap(Integer::sum)
+            .pairMapThrowing(Integer::sum)
             .onClose(ex.apply("After pairMap"))
             .append(4)
             .onClose(ex.apply("After append"))
@@ -123,7 +123,7 @@ public class BaseStreamExTest {
     public void testChain() {
         assertArrayEquals(new double[] { 2, 2, 6, 2, 6 },
             IntStreamEx.of(3, 4, 5).chain(IntStreamEx::boxed)
-                .chain(s -> s.flatMapToLong(LongStreamEx::range))
+                .chain(s -> s.flatMapToLongThrowing(LongStreamEx::range))
                 .chain(s -> s.filter(n -> n % 2 != 0).asDoubleStream())
                 .chain(s -> s.map(x -> x * 2)).toArray(), 0.0);
     }

--- a/src/test/java/one/util/streamex/api/CustomPoolTest.java
+++ b/src/test/java/one/util/streamex/api/CustomPoolTest.java
@@ -318,7 +318,7 @@ public class CustomPoolTest {
             t -> counter.incrementAndGet()).collect(MoreCollectors.onlyOne()));
         assertTrue(counter.get() < 10000);
         counter.set(0);
-        assertEquals(Optional.empty(), IntStreamEx.range(0, 10000).boxed().mapToEntry(x -> x).parallel(pool).peek(
+        assertEquals(Optional.empty(), IntStreamEx.range(0, 10000).boxed().mapNewValue(x -> x).parallel(pool).peek(
             this::checkThread).peek(t -> counter.incrementAndGet()).collect(MoreCollectors.onlyOne()));
         assertTrue(counter.get() < 10000);
     }

--- a/src/test/java/one/util/streamex/api/EntryStreamTest.java
+++ b/src/test/java/one/util/streamex/api/EntryStreamTest.java
@@ -99,13 +99,13 @@ public class EntryStreamTest {
         expected.put("aaa", 3);
         expected.put("bbb", 3);
         expected.put("c", 1);
-        assertEquals(expected, StreamEx.of("aaa", "bbb", "c").mapNewValue(String::length).toMap());
-        assertEquals(expected, StreamEx.of("aaa", "bbb", "c").mapToEntry(s -> s, String::length).toMap());
+        assertEquals(expected, StreamEx.of("aaa", "bbb", "c").mapNewValueThrowing(String::length).toMap());
+        assertEquals(expected, StreamEx.of("aaa", "bbb", "c").mapToEntryThrowing(s -> s, String::length).toMap());
         assertEquals(Collections.singletonMap("foo", 1), EntryStream.of("foo", 1).toMap());
         assertEquals(createMap(), EntryStream.of("a", 1, "bb", 22, "ccc", 33).toMap());
 
         assertEquals(expected, StreamEx.of(Collections.singletonMap("aaa", 3), Collections.singletonMap("bbb", 3),
-            Collections.singletonMap("c", 1), Collections.emptyMap()).flatMapToEntry(m -> m).toMap());
+            Collections.singletonMap("c", 1), Collections.emptyMap()).flatMapToEntryThrowing(m -> m).toMap());
 
         assertEquals(Collections.singletonMap("aaa", 3), EntryStream.of(
             Collections.singletonMap("aaa", 3).entrySet().spliterator()).toMap());

--- a/src/test/java/one/util/streamex/api/EntryStreamTest.java
+++ b/src/test/java/one/util/streamex/api/EntryStreamTest.java
@@ -99,7 +99,7 @@ public class EntryStreamTest {
         expected.put("aaa", 3);
         expected.put("bbb", 3);
         expected.put("c", 1);
-        assertEquals(expected, StreamEx.of("aaa", "bbb", "c").mapToEntry(String::length).toMap());
+        assertEquals(expected, StreamEx.of("aaa", "bbb", "c").mapNewValue(String::length).toMap());
         assertEquals(expected, StreamEx.of("aaa", "bbb", "c").mapToEntry(s -> s, String::length).toMap());
         assertEquals(Collections.singletonMap("foo", 1), EntryStream.of("foo", 1).toMap());
         assertEquals(createMap(), EntryStream.of("a", 1, "bb", 22, "ccc", 33).toMap());
@@ -605,13 +605,13 @@ public class EntryStreamTest {
         expected.put("aaa", asList(3));
         expected.put("bbb", asList(3, 3));
         expected.put("cc", asList(2));
-        assertEquals(expected, StreamEx.of("aaa", "bbb", "bbb", "cc").mapToEntry(String::length).grouping());
+        assertEquals(expected, StreamEx.of("aaa", "bbb", "bbb", "cc").mapNewValue(String::length).grouping());
 
         Map<String, List<Integer>> expectedDistinct = new LinkedHashMap<>();
         expectedDistinct.put("aaa", asList(3));
         expectedDistinct.put("bbb", asList(3));
         expectedDistinct.put("cc", asList(2));
-        assertEquals(expectedDistinct, StreamEx.of("aaa", "bbb", "bbb", "cc").mapToEntry(String::length).distinct()
+        assertEquals(expectedDistinct, StreamEx.of("aaa", "bbb", "bbb", "cc").mapNewValue(String::length).distinct()
                 .grouping());
     }
 
@@ -656,7 +656,7 @@ public class EntryStreamTest {
 
     @Test(expected = IllegalStateException.class)
     public void testCollision() {
-        StreamEx.of("aa", "aa").mapToEntry(String::length).toCustomMap(LinkedHashMap::new);
+        StreamEx.of("aa", "aa").mapNewValue(String::length).toCustomMap(LinkedHashMap::new);
     }
 
     @Test
@@ -777,7 +777,7 @@ public class EntryStreamTest {
             for (int i = n; i < 4; i++)
                 expected.put(i, i);
             streamEx(() -> IntStreamEx.range(4).atLeast(n).boxed(), s -> {
-                Map<Integer, Integer> map = s.get().mapToEntry(Function.identity()).toImmutableMap();
+                Map<Integer, Integer> map = s.get().mapNewValue(Function.identity()).toImmutableMap();
                 assertEquals(expected, map);
                 try {
                     map.put(-1, -1);

--- a/src/test/java/one/util/streamex/api/StreamExTest.java
+++ b/src/test/java/one/util/streamex/api/StreamExTest.java
@@ -209,7 +209,7 @@ public class StreamExTest {
             assertEquals(1, s.count());
         }
         assertEquals(1, i.get());
-        assertEquals(asList(1, 2), StreamEx.of("a", "bb").map(String::length).toList());
+        assertEquals(asList(1, 2), StreamEx.of("a", "bb").mapThrowing(String::length).toList());
         assertFalse(StreamEx.empty().findAny().isPresent());
         assertEquals("a", StreamEx.of("a").findAny().get());
         assertFalse(StreamEx.empty().findFirst().isPresent());
@@ -234,7 +234,7 @@ public class StreamExTest {
         assertTrue(StreamEx.of().allMatch("a"::equals));
         assertFalse(StreamEx.of().anyMatch("a"::equals));
 
-        assertEquals("abbccc", StreamEx.of("a", "bb", "ccc").collect(StringBuilder::new, StringBuilder::append,
+        assertEquals("abbccc", StreamEx.of("a", "bb", "ccc").collectThrowing(StringBuilder::new, StringBuilder::append,
             StringBuilder::append).toString());
         assertArrayEquals(new String[] { "a", "b", "c" }, StreamEx.of("a", "b", "c").toArray(String[]::new));
         assertArrayEquals(new Object[] { "a", "b", "c" }, StreamEx.of("a", "b", "c").toArray());
@@ -296,21 +296,21 @@ public class StreamExTest {
 
     @Test
     public void testFlatMap() {
-        assertArrayEquals(new int[] { 0, 0, 1, 0, 0, 1, 0, 0 }, StreamEx.of("111", "222", "333").flatMapToInt(s -> s
+        assertArrayEquals(new int[] { 0, 0, 1, 0, 0, 1, 0, 0 }, StreamEx.of("111", "222", "333").flatMapToIntThrowing(s -> s
                 .chars().map(ch -> ch - '0')).pairMap((a, b) -> b - a).toArray());
-        assertArrayEquals(new long[] { 0, 0, 1, 0, 0, 1, 0, 0 }, StreamEx.of("111", "222", "333").flatMapToLong(s -> s
+        assertArrayEquals(new long[] { 0, 0, 1, 0, 0, 1, 0, 0 }, StreamEx.of("111", "222", "333").flatMapToLongThrowing(s -> s
                 .chars().mapToLong(ch -> ch - '0')).pairMap((a, b) -> b - a).toArray());
-        assertArrayEquals(new double[] { 0, 0, 1, 0, 0, 1, 0, 0 }, StreamEx.of("111", "222", "333").flatMapToDouble(
+        assertArrayEquals(new double[] { 0, 0, 1, 0, 0, 1, 0, 0 }, StreamEx.of("111", "222", "333").flatMapToDoubleThrowing(
             s -> s.chars().mapToDouble(ch -> ch - '0')).pairMap((a, b) -> b - a).toArray(), 0.0);
     }
 
     @Test
     public void testAndThen() {
-        HashSet<String> set = StreamEx.of("a", "bb", "ccc").toListAndThen(HashSet::new);
+        HashSet<String> set = StreamEx.of("a", "bb", "ccc").toListAndThenThrowing(HashSet::new);
         assertEquals(3, set.size());
         assertTrue(set.contains("bb"));
 
-        ArrayList<String> list = StreamEx.of("a", "bb", "ccc").toSetAndThen(ArrayList::new);
+        ArrayList<String> list = StreamEx.of("a", "bb", "ccc").toSetAndThenThrowing(ArrayList::new);
         assertEquals(3, list.size());
         assertTrue(list.contains("bb"));
 
@@ -460,7 +460,7 @@ public class StreamExTest {
         expectedMapSet.put(3, new HashSet<>(asList("ccc")));
 
         streamEx(() -> StreamEx.of("a", "bb", "dd", "ccc"), supplier -> {
-            assertEquals(expected, supplier.get().groupingBy(String::length));
+            assertEquals(expected, supplier.get().groupingByThrowing(String::length));
             Map<Integer, List<String>> map = supplier.get().groupingTo(String::length, LinkedList::new);
             assertEquals(expected, map);
             assertTrue(map.get(1) instanceof LinkedList);
@@ -534,7 +534,7 @@ public class StreamExTest {
         data.put(1, asList("a", "b"));
         data.put(2, asList("c", "d"));
         data.put(3, null);
-        assertEquals(asList("a", "b", "c", "d"), StreamEx.of(data.entrySet()).flatCollection(Entry::getValue).toList());
+        assertEquals(asList("a", "b", "c", "d"), StreamEx.of(data.entrySet()).flatCollectionThrowing(Entry::getValue).toList());
     }
 
     @Test
@@ -543,7 +543,7 @@ public class StreamExTest {
         data.put(1, new String[] {"a", "b"});
         data.put(2, new String[] {"c", "d"});
         data.put(3, null);
-        assertEquals(asList("a", "b", "c", "d"), StreamEx.of(data.entrySet()).flatArray(Entry::getValue).toList());
+        assertEquals(asList("a", "b", "c", "d"), StreamEx.of(data.entrySet()).flatArrayThrowing(Entry::getValue).toList());
     }
 
     @Test
@@ -610,7 +610,7 @@ public class StreamExTest {
     @Test
     public void testPrependTSO() {
         List<Integer> expected = IntStreamEx.rangeClosed(19999, 0, -1).boxed().toList();
-        assertEquals(expected, IntStreamEx.range(20000).mapToObj(StreamEx::of).reduce(StreamEx::prepend).get()
+        assertEquals(expected, IntStreamEx.range(20000).mapToObj(StreamEx::of).reduceThrowing(StreamEx::prepend).get()
                 .toList());
         assertEquals(expected, IntStreamEx.range(20000).parallel().mapToObj(StreamEx::of).reduce(StreamEx::prepend)
                 .get().toList());
@@ -728,7 +728,7 @@ public class StreamExTest {
             assertTrue(supplier.get().foldLeft(false, (Boolean acc, String s) -> acc || s.equals("bb")));
             assertFalse(supplier.get().foldLeft(false, (Boolean acc, String s) -> acc || s.equals("d")));
             assertEquals(6, (int) supplier.get().foldLeft(0, (acc, v) -> acc + v.length()));
-            assertEquals("{ccc={bb={a={}}}}", supplier.get().foldLeft(Collections.emptyMap(), (Map<String, Object> acc,
+            assertEquals("{ccc={bb={a={}}}}", supplier.get().foldLeftThrowing(Collections.emptyMap(), (Map<String, Object> acc,
                     String v) -> Collections.singletonMap(v, acc)).toString());
         });
     }
@@ -746,7 +746,7 @@ public class StreamExTest {
 
     @Test
     public void testFoldRight() {
-        assertEquals(";c;b;a", StreamEx.of("a", "b", "c").parallel().foldRight("", (u, v) -> v + ";" + u));
+        assertEquals(";c;b;a", StreamEx.of("a", "b", "c").parallel().foldRightThrowing("", (u, v) -> v + ";" + u));
         assertEquals("{a={bb={ccc={}}}}", StreamEx.of("a", "bb", "ccc").foldRight(Collections.emptyMap(), (BiFunction<String, Map<String, Object>, Map<String, Object>>) Collections::singletonMap).toString());
         assertEquals("{a={bb={ccc={}}}}", StreamEx.of("a", "bb", "ccc").parallel().foldRight(Collections.emptyMap(), (BiFunction<String, Map<String, Object>, Map<String, Object>>) Collections::singletonMap).toString());
     }


### PR DESCRIPTION
Hi !
I would to push 2 waves of new functionnalities for the streamEx library.
My actual push needs a lot more of work to be totally validated but i would like to know if the idea i would like to push may interest you and i would like to be sure that my final completed version will be merged in master with your validation when everything will be ok for you.

Here, my push contains only elements of the first wave. If you are interested, i could push a new branch with elements of second wave that i have already started to implement.

The idea of my first wave is to introduce Throwable functions interface in methods of Stream. 
These functional interfaces are likely the same as FunctionalInteface java like Function, Consumer, Supplier except the apply method accept to throw an Exception.
Then, all methods of Stream like, map, flatMap, [...] that take a Function, Consumer, Supplier in parameter will have duplicated methods like this : 
 - methodThrowing (like mapThrowing, flatMapThrowing, ...) that takes Throwable functions instead and this method will declare the exception thrown.
 - tryMethod (like tryMap, tryFlatMap, ...) that takes as same Throwable functions and this method will hide declaration of the exception thrown. The exception will be thrown in sneaky way.

In final these 2 new methods on each method of Stream will call their conventional equivalent : mapThrowing calls tryMap that calls map. The difference is not in the functionality of the map but that the method can accept Throwable functions with 2 options : 
 - declare the exception
 - hide the exception

In the **StreamExInternalTest** class, i have created some tests to explain in details the interest of this idea with commentary to help to explain.
Also, to quickly increase my percentage of code cover, i have replaced some call methods of your tests to use the throwing functions instead the conventional. In this way, you can also see that the new functions accepts methods that not throwing too.

If the idea please you but you are not agree with some syntax or any thing else, it is not a problem with me : you can propose any changes. I will adapt.
In this way, i have created a package-info.java in functionex package more like a free discussion for now to talk about some conventions of naming.
And, if the idea please you, i will not say no for some help :). Above all, in javadocs because my english is shaky.

The following actions is to continue to create new methods for other StreamEx functions that I skip for now.

In second, I would like too, to move the package functionex in another lib and streamEx will use it.
For the second wave that i would like to propose, i need Throwable Functions classes but StreamEx is not needed (for now, but maybe, i'm wrong :) ).
It would be interesting to not oblige users to integrate all the classes of my second wave if not needed in their application. But we will can talk about that later.

Thank you for giving me your attention.
