### PR TITLE
implement `mapToEntryPartial`

### DIFF
--- a/src/main/java/one/util/streamex/StreamEx.java
+++ b/src/main/java/one/util/streamex/StreamEx.java
@@ -173,8 +173,7 @@ public final class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
      *        element
      * @return the new stream
      */
-    public <V> EntryStream<T, V>
-    mapToEntry(Function<? super T, ? extends V> valueMapper) {
+    public <V> EntryStream<T, V> mapToEntry(Function<? super T, ? extends V> valueMapper) {
         return new EntryStream<>(stream().map(e -> new SimpleImmutableEntry<>(e, valueMapper.apply(e))), context);
     }
 

--- a/src/main/java/one/util/streamex/StreamEx.java
+++ b/src/main/java/one/util/streamex/StreamEx.java
@@ -395,6 +395,48 @@ public final class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
     }
 
     /**
+     *
+     * Returns an {@link EntryStream} consisting of the {@link Entry} objects
+     * which keys are elements of this stream and values are results of applying
+     * the given partial function to the elements of this stream
+     * removing the elements to which the function is not applicable.
+     *
+     * <p>
+     * If the mapping function returns {@link Optional#empty()}, the original
+     * value will be removed from the resulting stream. The mapping function
+     * may not return null.
+     *
+     * <p>
+     * This is an <a href="package-summary.html#StreamOps">intermediate
+     * operation</a>.
+     *
+     * <p>
+     * The {@code mapToEntryPartial()} operation has the effect of applying a
+     * one-to-zero-or-one transformation to the elements of the stream, and then
+     * flattening the resulting elements into a new stream.
+     *
+     * @param <V> The {@code Entry} value type
+     * @param valueMapper a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        partial function to apply to each element which returns a present optional
+     *        if it's applicable, or an empty optional otherwise
+     * @return the new stream
+     * @since 0.8.4
+     *
+     * @see AbstractStreamEx#mapPartial(Function)
+     */
+    public <V> EntryStream<T, ? extends V> mapToEntryPartial(Function<? super T, ? extends Optional<? extends V>> valueMapper){
+        return new EntryStream<>(
+                stream()
+                        .map(e -> {
+                            Optional<? extends V> s = valueMapper.apply(e);
+                            return s.isPresent() ? new SimpleImmutableEntry<>(e, s.get()) : null;
+                        })
+                        .filter(Objects::nonNull), context);
+    }
+
+    /**
      * Performs a cross product of current stream with specified array of
      * elements. As a result the {@link EntryStream} is created whose keys are
      * elements of current stream and values are elements of the specified

--- a/src/main/java/one/util/streamex/StreamEx.java
+++ b/src/main/java/one/util/streamex/StreamEx.java
@@ -173,7 +173,8 @@ public final class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
      *        element
      * @return the new stream
      */
-    public <V> EntryStream<T, V> mapToEntry(Function<? super T, ? extends V> valueMapper) {
+    public <V> EntryStream<T, V>
+    mapToEntry(Function<? super T, ? extends V> valueMapper) {
         return new EntryStream<>(stream().map(e -> new SimpleImmutableEntry<>(e, valueMapper.apply(e))), context);
     }
 
@@ -427,13 +428,10 @@ public final class StreamEx<T> extends AbstractStreamEx<T, StreamEx<T>> {
      * @see AbstractStreamEx#mapPartial(Function)
      */
     public <V> EntryStream<T, ? extends V> mapToEntryPartial(Function<? super T, ? extends Optional<? extends V>> valueMapper){
-        return new EntryStream<>(
-                stream()
-                        .map(e -> {
-                            Optional<? extends V> s = valueMapper.apply(e);
-                            return s.isPresent() ? new SimpleImmutableEntry<>(e, s.get()) : null;
-                        })
-                        .filter(Objects::nonNull), context);
+        return new EntryStream<>(stream().map(e -> {
+            Optional<? extends V> s = valueMapper.apply(e);
+            return s.isPresent() ? new SimpleImmutableEntry<>(e, s.get()) : null;
+        }).filter(Objects::nonNull), context);
     }
 
     /**

--- a/src/test/java/one/util/streamex/api/StreamExTest.java
+++ b/src/test/java/one/util/streamex/api/StreamExTest.java
@@ -2203,6 +2203,17 @@ public class StreamExTest {
     }
 
     @Test
+    public void testMapToEntryPartial() {
+        Function<Integer, Optional<String>> literalOf = num -> num == 1
+                ? Optional.of("one")
+                : Optional.empty();
+
+        List<Integer> original = asList(1, 2, 3, 4);
+        Map<Integer, String> expected = Collections.singletonMap(1, "one");
+        streamEx(original::stream, s -> assertEquals(expected, s.get().mapToEntryPartial(literalOf).toMap()));
+    }
+
+    @Test
     public void testConcurrentGroupingBy() {
         StreamEx.of("a", "b").parallel().groupingBy(String::length, secondConcurrentAddAssertingCollector("a", "b"));
         StreamEx.of("x", "y").parallel()


### PR DESCRIPTION
Follows https://github.com/amaembo/streamex/pull/183 and https://github.com/amaembo/streamex/commit/78c049042b1e4784fd2e14fc30dcff3cb3a0384d, which introduced

`StreamEx.mapPartial`, `EntryStream.mapToKeyPartial/mapToValuePartial/mapKeyValuePartial`


This PR implements `EntryStream.mapToEntryPartial`, which takes a partial value mapper `Function<K, Optional<V>>` and returns an `EntryStream<K, V>` with the empty optionals removed. 

The intention is to replace
```
StreamEx.of(x).mapToEntry(partialFunction).flatMapValues(Optional::stream);
```
with
```
StreamEx.of(x).mapToEntryPartial(partialFunction);
```

