### PR TITLE
Add `mapKeysPartial` and `mapValuesPartial` to `EntryStream`

### DIFF
--- a/src/main/java/one/util/streamex/EntryStream.java
+++ b/src/main/java/one/util/streamex/EntryStream.java
@@ -507,7 +507,7 @@ public final class EntryStream<K, V> extends AbstractStreamEx<Entry<K, V>, Entry
      *
      */
     public <KK> EntryStream<KK, V> mapKeysPartial(Function<? super K, ? extends Optional<? extends KK>> keyMapper) {
-        return new EntryStream<>(stream().map(e -> new SimpleImmutableEntry<>((KK) keyMapper.apply(e.getKey()).orElse(null), e.getValue())).filter(e -> e.getKey() != null), context);
+        return mapToKeyPartial((k, _v) -> keyMapper.apply(k));
     }
 
     /**
@@ -558,7 +558,7 @@ public final class EntryStream<K, V> extends AbstractStreamEx<Entry<K, V>, Entry
      * @since 0.8.4
      */
     public <VV> EntryStream<K, VV> mapValuesPartial(Function<? super V, ? extends Optional<? extends VV>> valueMapper) {
-        return new EntryStream<>(stream().map(e -> new SimpleImmutableEntry<>(e.getKey(), (VV) valueMapper.apply(e.getValue()).orElse(null))).filter(e -> e.getValue() != null), context);
+        return mapToValuePartial((_k, v) -> valueMapper.apply(v));
     }
 
     /**

--- a/src/main/java/one/util/streamex/EntryStream.java
+++ b/src/main/java/one/util/streamex/EntryStream.java
@@ -478,6 +478,40 @@ public final class EntryStream<K, V> extends AbstractStreamEx<Entry<K, V>, Entry
 
     /**
      * Returns an {@code EntryStream} consisting of the entries whose keys are
+     * modified by applying the given partial function to keys of this {@code EntryStream}
+     * and removing the keys to which the function is not applicable. The values are left
+     * unchanged.
+     *
+     * <p>
+     * If the mapping function returns {@link Optional#empty()}, the original
+     * key will be removed from the resulting {@code EntryStream}. The mapping function
+     * may not return null.
+     *
+     * <p>
+     * This is an <a href="package-summary.html#StreamOps">intermediate
+     * operation</a>.
+     *
+     * <p>
+     * The {@code mapKeysPartial()} operation has the effect of applying a
+     * one-to-zero-or-one transformation to the keys of the {@code EntryStream},
+     * and then flattening the resulting elements into a new stream.
+     *
+     * @param <KK> The element type of keys in the new {@code EntryStream}
+     * @param keyMapper a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        partial function to apply to each key which returns a present optional
+     *        if it's applicable, or an empty optional otherwise
+     * @return the new stream
+     * @since 0.8.4
+     *
+     */
+    public <KK> EntryStream<KK, V> mapKeysPartial(Function<? super K, ? extends Optional<? extends KK>> keyMapper) {
+        return new EntryStream<>(stream().map(e -> new SimpleImmutableEntry<>((KK) keyMapper.apply(e.getKey()).orElse(null), e.getValue())).filter(e -> e.getKey() != null), context);
+    }
+
+    /**
+     * Returns an {@code EntryStream} consisting of the entries whose keys are
      * left unchanged and values are modified by applying the given function.
      *
      * <p>
@@ -492,6 +526,39 @@ public final class EntryStream<K, V> extends AbstractStreamEx<Entry<K, V>, Entry
     public <VV> EntryStream<K, VV> mapValues(Function<? super V, ? extends VV> valueMapper) {
         return new EntryStream<>(stream().map(
             e -> new SimpleImmutableEntry<>(e.getKey(), valueMapper.apply(e.getValue()))), context);
+    }
+
+    /**
+     * Returns an {@code EntryStream} consisting of the entries whose values are
+     * modified by applying the given partial function to values of this {@code EntryStream}
+     * and removing the values to which the function is not applicable. The keys are left
+     * unchanged.
+     *
+     * <p>
+     * If the mapping function returns {@link Optional#empty()}, the original
+     * value will be removed from the resulting {@code EntryStream}. The mapping function
+     * may not return null.
+     *
+     * <p>
+     * This is an <a href="package-summary.html#StreamOps">intermediate
+     * operation</a>.
+     *
+     * <p>
+     * The {@code mapValuesPartial()} operation has the effect of applying a
+     * one-to-zero-or-one transformation to the keys of the {@code EntryStream},
+     * and then flattening the resulting elements into a new stream.
+     *
+     * @param <VV> The element type of keys in the new {@code EntryStream}
+     * @param valueMapper a <a
+     *        href="package-summary.html#NonInterference">non-interfering </a>,
+     *        <a href="package-summary.html#Statelessness">stateless</a>
+     *        partial function to apply to each value which returns a present optional
+     *        if it's applicable, or an empty optional otherwise
+     * @return the new stream
+     * @since 0.8.4
+     */
+    public <VV> EntryStream<K, VV> mapValuesPartial(Function<? super V, ? extends Optional<? extends VV>> valueMapper) {
+        return new EntryStream<>(stream().map(e -> new SimpleImmutableEntry<>(e.getKey(), (VV) valueMapper.apply(e.getValue()).orElse(null))).filter(e -> e.getValue() != null), context);
     }
 
     /**

--- a/src/test/java/one/util/streamex/api/EntryStreamTest.java
+++ b/src/test/java/one/util/streamex/api/EntryStreamTest.java
@@ -268,6 +268,29 @@ public class EntryStreamTest {
     }
 
     @Test
+    public void testMapKeysPartial() {
+        Map<Integer, Integer> original = new HashMap<>();
+        original.put(1, 1);
+        original.put(2, 2);
+        original.put(3, 3);
+        original.put(4, 4);
+
+        Map<Integer, Integer> expected = new HashMap<>();
+        expected.put(1, 2);
+        expected.put(2, 4);
+
+        Map<Integer, Integer> actual = EntryStream.of(original)
+                .mapKeysPartial(key -> {
+                    if (key % 2 == 0) {
+                        return Optional.of(key / 2);
+                    }
+                    return Optional.empty();
+                }).toMap();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void testMapValues() {
         Map<String, String> expected = new HashMap<>();
         expected.put("a", "1");
@@ -275,6 +298,29 @@ public class EntryStreamTest {
         expected.put("ccc", "33");
         Map<String, String> result = EntryStream.of(createMap()).mapValues(String::valueOf).toMap();
         assertEquals(expected, result);
+    }
+
+    @Test
+    public void testMapValuesPartial() {
+        Map<Integer, Integer> original = new HashMap<>();
+        original.put(1, 1);
+        original.put(2, 2);
+        original.put(3, 3);
+        original.put(4, 4);
+
+        Map<Integer, Integer> expected = new HashMap<>();
+        expected.put(2, 1);
+        expected.put(4, 2);
+
+        Map<Integer, Integer> actual = EntryStream.of(original)
+                .mapValuesPartial(value -> {
+                    if (value % 2 == 0) {
+                        return Optional.of(value / 2);
+                    }
+                    return Optional.empty();
+                }).toMap();
+
+        assertEquals(expected, actual);
     }
 
     @Test


### PR DESCRIPTION
When operating over an `EntryStream`, a common pattern is to call a mapping function on the keys or values that returns an `Optional<K>` or `Optional<V>`.  As is, one can remove empty Optionals by using `flatMap(Keys|Values)(Optional::stream)` or `mapTo(Key|Value)Partial(partialFunction)`:
```java
EntryStream.of(x).mapKeys(partialFunction).flatMapKeys(Optional::stream);
// OR
EntryStream.of(x).mapToKeyPartial((key, _value) -> partialFunction(key));
```
The former introduces an extra allocation for every entry, while the latter isn't the most ergonomic solution. 

As a result, this PR implements `EntryStream.mapKeysPartial` and `EntryStream.mapValuesPartial`, which takes a partial key/value mapper `Function<K, Optional<KK>>` and returns an `EntryStream<KK, V>` with the empty optionals removed. This makes it possible to now do the following:
```java
EntryStream.of(x).mapKeysPartial(partialFunction);
```